### PR TITLE
README.rst: formatting + link to readthedoc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,14 +9,27 @@ Install
 
 Get the python modules:
 
+.. code-block:: bash
+
   pip install -r requirements.txt
 
 Copy servermon/settings.py.dist to servermon/settings.py
 
 See doc/install.rst for details.
 
+.. code-block:: bash
+
     ./manage.py syncdb
     ./manage.py migrate
 
 Run!
+
+.. code-block:: bash
+
     ./manage.py runserver
+
+Documentation
+=============
+
+The documentation is maintained using Sphinx (under /doc/) and is automatically
+generated at https://servermon.readthedocs.org/.


### PR DESCRIPTION
I have added an entry for https://servermon.readthedocs.org/ a service
which build Sphinx documentation for us and provide web hosting for
anyone to look at the doc.

While at it, also used code-block for the shell snippets.
