### PR TITLE
require Django >=1.2 but < 1.5 + link to tutorial

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,12 @@ servermon
 Servermon is a Django project with the aim of facilitating server monitoring
 and management through Puppet.
 
+Compatibility
+=============
+
+As of October 2013, we mosty support Django 1.4. Django 1.5 or later is NOT
+supported.
+
 Install
 =======
 
@@ -27,6 +33,8 @@ Run!
 .. code-block:: bash
 
     ./manage.py runserver
+
+More details in the `installation tutorial <https://servermon.readthedocs.org/en/latest/install.html>`_.
 
 Documentation
 =============

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pbr
-Django
+Django>=1.2,<1.5
 south
 whoosh
 ipy


### PR DESCRIPTION
Alexandros told me that supporting Django 1.5 is on the plan but not
ready yet, so be safe and require at most 1.4.x.

Running tests with tox would install the latest 1.4 version for us. One
could do that using:

 tox -epy27

Eventually want to recreate the env with: tox -epy27 -r
