### PR TITLE
tox test was pointing to old manage.py location

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ setenv = VIRTUAL_ENV={envdir}
 install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-commands = python manage.py test --noinput
+commands = python ./servermon/manage.py test --noinput
 
 [testenv:venv]
 commands = {posargs}


### PR DESCRIPTION
manage.py has been moved to /servermon/manage.py but the tox.ini has not
been altered.  Merely update the path.
