### PR TITLE
Adding support for storing InRow AC

### DIFF
--- a/servermon/hwdoc/fixtures/vendor-model.json
+++ b/servermon/hwdoc/fixtures/vendor-model.json
@@ -112,6 +112,7 @@
     "fields": {
       "vendor": 5, 
       "name": "NetShelter SX",
+      "inrow_ac": false,
       "max_mounting_depth": 91,
       "min_mounting_depth": 19,
       "height": 42,
@@ -124,6 +125,7 @@
     "fields": {
       "vendor": 5, 
       "name": "InRow RP DX Air Cooled 380-415V 50 Hz ACRP102",
+      "inrow_ac": true,
       "max_mounting_depth": 0,
       "min_mounting_depth": 0,
       "height": 42,
@@ -136,6 +138,7 @@
     "fields": {
       "vendor": 5, 
       "name": "InRow RP Chilled Water 380-415V 50 Hz ACRP502",
+      "inrow_ac": true,
       "max_mounting_depth": 0,
       "min_mounting_depth": 0,
       "height": 42,

--- a/servermon/hwdoc/migrations/0022_auto__add_field_rackmodel_inrow_ac.py
+++ b/servermon/hwdoc/migrations/0022_auto__add_field_rackmodel_inrow_ac.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'RackModel.inrow_ac'
+        db.add_column('hwdoc_rackmodel', 'inrow_ac',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'RackModel.inrow_ac'
+        db.delete_column('hwdoc_rackmodel', 'inrow_ac')
+
+
+    models = {
+        'hwdoc.datacenter': {
+            'Meta': {'object_name': 'Datacenter'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        'hwdoc.email': {
+            'Meta': {'object_name': 'Email'},
+            'email': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'hwdoc.equipment': {
+            'Meta': {'ordering': "['rack', '-unit']", 'object_name': 'Equipment'},
+            'added': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'allocation': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Project']", 'null': 'True', 'blank': 'True'}),
+            'comments': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.EquipmentModel']"}),
+            'purpose': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'rack': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Rack']", 'null': 'True', 'blank': 'True'}),
+            'serial': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'unit': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        'hwdoc.equipmentmodel': {
+            'Meta': {'object_name': 'EquipmentModel'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'rack_back': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'rack_front': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'rack_interior': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'u': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'vendor': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Vendor']"})
+        },
+        'hwdoc.person': {
+            'Meta': {'object_name': 'Person'},
+            'emails': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['hwdoc.Email']", 'symmetrical': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'phones': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['hwdoc.Phone']", 'symmetrical': 'False'}),
+            'surname': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.phone': {
+            'Meta': {'object_name': 'Phone'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'number': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.project': {
+            'Meta': {'object_name': 'Project'},
+            'contacts': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['hwdoc.Person']", 'through': "orm['hwdoc.Role']", 'symmetrical': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.rack': {
+            'Meta': {'object_name': 'Rack'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.RackModel']"}),
+            'mounted_depth': ('django.db.models.fields.PositiveIntegerField', [], {'default': '60', 'max_length': '10'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.rackmodel': {
+            'Meta': {'object_name': 'RackModel'},
+            'height': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '10'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'inrow_ac': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'max_mounting_depth': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '10'}),
+            'min_mounting_depth': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '10'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'vendor': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Vendor']"}),
+            'width': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '10'})
+        },
+        'hwdoc.rackposition': {
+            'Meta': {'ordering': "['position']", 'object_name': 'RackPosition'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'position': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '20'}),
+            'rack': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['hwdoc.Rack']", 'unique': 'True'}),
+            'rr': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.RackRow']"})
+        },
+        'hwdoc.rackrow': {
+            'Meta': {'object_name': 'RackRow'},
+            'dc': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Datacenter']", 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.role': {
+            'Meta': {'object_name': 'Role'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Person']"}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Project']"}),
+            'role': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.servermanagement': {
+            'Meta': {'object_name': 'ServerManagement'},
+            'added': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'equipment': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['hwdoc.Equipment']", 'unique': 'True'}),
+            'hostname': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'license': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'mac': ('django.db.models.fields.CharField', [], {'max_length': '17', 'blank': 'True'}),
+            'method': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'raid_license': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'})
+        },
+        'hwdoc.vendor': {
+            'Meta': {'object_name': 'Vendor'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        }
+    }
+
+    complete_apps = ['hwdoc']

--- a/servermon/hwdoc/models.py
+++ b/servermon/hwdoc/models.py
@@ -134,6 +134,7 @@ class RackModel(Model):
     min_mounting_depth = models.PositiveIntegerField(max_length=10)
     height = models.PositiveIntegerField(max_length=10)
     width = models.PositiveIntegerField(max_length=10)
+    inrow_ac = models.BooleanField(default=False)
 
     def __unicode__(self):
         return "%s %s" % (self.vendor, self.name)

--- a/servermon/hwdoc/tests.py
+++ b/servermon/hwdoc/tests.py
@@ -50,6 +50,7 @@ class EquipmentTestCase(unittest.TestCase):
         self.model2 = EquipmentModel.objects.create(vendor=self.vendor, name='Fujisu PRIMERGY 200 S', u=1)
         self.rackmodel = RackModel.objects.create(
                                 vendor=self.vendor,
+                                inrow_ac=False,
                                 max_mounting_depth = 99,
                                 min_mounting_depth = 19,
                                 height = 42,
@@ -167,6 +168,7 @@ class ViewsTestCase(unittest.TestCase):
         self.model = EquipmentModel.objects.create(vendor=self.vendor, name='DL 385 G7', u=2)
         self.rackmodel = RackModel.objects.create(
                                 vendor=self.vendor,
+                                inrow_ac=False,
                                 max_mounting_depth = 99,
                                 min_mounting_depth = 19,
                                 height = 42,
@@ -295,6 +297,7 @@ class CommandsTestCase(unittest.TestCase):
         self.model2 = EquipmentModel.objects.create(vendor=self.vendor, name='Fujisu PRIMERGY 200 S', u=1)
         self.rackmodel = RackModel.objects.create(
                                 vendor=self.vendor,
+                                inrow_ac=False,
                                 max_mounting_depth = 99,
                                 min_mounting_depth = 19,
                                 height = 42,


### PR DESCRIPTION
InRow cooling units are now distinguished from normal Rack units by a
field called inrow_ac in their RackModel. This changes not the way
anything is displayed. This closes #19
