### PR TITLE
Add to contrib dir a shellscript for automating version updates

### DIFF
--- a/contrib/update-servermon.sh
+++ b/contrib/update-servermon.sh
@@ -130,7 +130,6 @@ if test -z "$host_name"; then
 	exit 1
 fi
 USER="${USER:-\`id -urn\`}"
-HOME="${HOME:-/home/$USER}"
 today=`date +%Y%m%d`
 # use specified commit or the "latest" one
 if test $# -gt 0; then
@@ -146,8 +145,9 @@ scp servermon-${today}-${commit_hash}.tar.xz "${host_name}:"
 ssh_cmds="\
 set -e;\
 sudo -s -n;\
+HOME=\"\${HOME:-/home/$USER}\";\
 cd \"$parent_path\";\
-tar xpJf \"${HOME}/servermon-${today}-${commit_hash}.tar.xz\";\
+tar xpJf \"\${HOME}/servermon-${today}-${commit_hash}.tar.xz\";\
 chown -R www-data:www-data \"${base_prefix}-${commit_hash}\";\
 chmod -R ug=rwX,o= \"${base_prefix}-${commit_hash}\";\
 if test -e \"${base_prefix}/urls.py\"; then\


### PR DESCRIPTION
This is a _prototype_ of an automated-update shell script, and even when tested I think it is probably only appropriate for the contrib directory (perhaps with a pointer to it somewhere in the docs, along with the appropriate warnings about the risks of automating things). Take it or leave it (I won't be offended...). I haven't yet battle-tested this, and would personally appreciate any bug-flushing, regardless whether it gets pulled to the servermon repo or not. Of course if you do pull this then _please_ include an extra commit to replace all the license comment-noise at the beginning with whatever is appropriate. That filler was just the sleep-deprivation and tea-overload talking...
