### PR TITLE
Make IPMI links in equipment view https

### DIFF
--- a/servermon/hwdoc/templates/equipment.html
+++ b/servermon/hwdoc/templates/equipment.html
@@ -21,7 +21,7 @@
         <tr><th>{% trans "Rack Unit" %}:</th><td>{{ equipment.rack }}{{ equipment.unit|stringformat:"02d" }}</td></tr>
         <tr><th>{% trans "Purpose" %}:</th><td>{{ equipment.purpose }}</td></tr>
         <tr><th>{% trans "OOB MAC" %}:</th><td>{% if equipment.servermanagement %}{{ equipment.servermanagement.mac }}{% endif %}</td></tr>
-        <tr><th>{% trans "OOB Hostname" %}:</th><td>{% if equipment.servermanagement %}<a href="http://{{ equipment.servermanagement.hostname }}">{{ equipment.servermanagement.hostname }}</a>{% endif %}</td></tr>
+        <tr><th>{% trans "OOB Hostname" %}:</th><td>{% if equipment.servermanagement %}<a href="https://{{ equipment.servermanagement.hostname }}">{{ equipment.servermanagement.hostname }}</a>{% endif %}</td></tr>
         <tr><th>{% trans "Tickets" %}:</th><td>
             {% for ticket in equipment.ticket_set.all %}
             <a href="{{ ticket.url }}">{{ ticket.name }}</a>{% if not forloop.last %},{% endif %}


### PR DESCRIPTION
This makes the IPMI links in the equipment view https, the same as in other views.

PS: I don't have access to my normal tools at the moment so I fork-and-edited this purely through the browser, hence why I'm PR-ing from my master branch (and why it is not presently entirely synced to upstream master, but it doesn't seem to cause any conflicts).
