### PR TITLE
Tiny spelling fix in install and README docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ and management through Puppet.
 Servermon at this point offers two applications
 
 1) A Web frontend to the Puppet database.
-2) hwodc: A simple datacenter hardware documentation database
+2) hwdoc: A simple datacenter hardware documentation database
 
 If you have no idea what Puppet is, it is possible that you don't need
 this software. Do note however that hwdoc will still be usable even

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -34,7 +34,7 @@ the corresponding sections.
 Servermon at this point offers two applications
 
 1) A Web frontend to the Puppet database.
-2) hwodc: A simple datacenter hardware documentation database
+2) hwdoc: A simple datacenter hardware documentation database
 
 If you have no idea what Puppet is, it is possible that you don't need
 this software. Do note however that hwdoc will still be usable even


### PR DESCRIPTION
Just to clear a typo which catches my eye every time...
