### PR TITLE
In ldap auth filter escape chars in uid input&add inetOrgPerson check

### DIFF
--- a/servermon/djangobackends/ldapBackend.py
+++ b/servermon/djangobackends/ldapBackend.py
@@ -19,6 +19,7 @@ Backend to provide LDAP authentication
 '''
 
 import ldap
+import ldap.filter
 
 from django.contrib.auth.models import User, UserManager, Permission, Group
 from django.conf import settings
@@ -48,7 +49,7 @@ class ldapBackend:
     def _auth_user(self, base, username, password, l):
 
         scope = ldap.SCOPE_SUBTREE
-        filter = '(uid=%s)' % username
+        filter = "(uid=%s)" % ldap.filter.escape_filter_chars(username, escape_mode=0)
         ret = ['dn', 'mail', 'givenName', 'sn']
         try:
             result_id = l.search(base, scope, filter, ret)


### PR DESCRIPTION
This uses ldap module's escape_filter_chars filter to prevent opportunity for injection attack in the provided uid, and adds a check on inetOrgPerson property to the authentication. Warning: I haven't actually tested this yet but wanted to PR it now. If you are able and willing to test it feel free, or if you want me to do it, then please wait until I add a comment to this PR saying I've tested it.
