### PR TITLE
ldapBackend.py: Do user.save() after user-create's add-group

### DIFF
--- a/servermon/djangobackends/ldapBackend.py
+++ b/servermon/djangobackends/ldapBackend.py
@@ -76,22 +76,20 @@ class ldapBackend:
                 user.email = result_data[0][1]['mail'][0]
                 user.first_name = result_data[0][1]['givenName'][0]
                 user.last_name = result_data[0][1]['sn'][0]
-                user.is_active = True
-                user.save()
             except:
                 user = User.objects.create_user(username, result_data[0][1]['mail'][0], None)
                 user.first_name = result_data[0][1]['givenName'][0]
                 user.last_name = result_data[0][1]['sn'][0]
                 user.is_staff = settings.LDAP_AUTH_IS_STAFF
                 user.is_superuser = False
-                user.is_active = True
                 if settings.LDAP_AUTH_GROUP:
                     try:
                         g = Group.objects.get(name=settings.LDAP_AUTH_GROUP)
                         user.groups.add(g)
-                        user.save()
                     except:
                         pass
+            user.is_active = True
+            user.save()
             return user
 
         except ldap.INVALID_CREDENTIALS:


### PR DESCRIPTION
- When a user doesn't exist and needs to be populated from ldap, the
  user.save() is located inside the conditional code for setting
  LDAP_AUTH_GROUP. This commit moves it after that so the save() always
  happens (even if LDAP_AUTH_GROUP is set in settings.py it might bork
  before the save() if the group doesn't exist).
- Also moved it and the user.is_active assignment to after the
  "user-exists" try-except block, to be more DRY
