### PR TITLE
Fix rendering of equipment without location info (fixes #69)

### DIFF
--- a/servermon/hwdoc/templates/equipment.html
+++ b/servermon/hwdoc/templates/equipment.html
@@ -18,7 +18,7 @@
         <tr><th>{% trans "Project" %}:</th><td>{% if equipment.allocation %}<a href="{% url "hwdoc.views.project" equipment.allocation.pk %}">{{ equipment.allocation.name }}</a>{% else %}-{% endif %}</td></tr>
         <tr><th>{% trans "Model" %}:</th><td>{{ equipment.model }}</td></tr>
         <tr><th>{% trans "Serial" %}:</th><td>{{ equipment.serial }}</td></tr>
-        <tr><th>{% trans "Rack Unit" %}:</th><td>{{ equipment.rack }}{{ equipment.unit|stringformat:"02d" }}</td></tr>
+        <tr><th>{% trans "Rack Unit" %}:</th><td>{% if equipment.rack %}{{ equipment.rack }}{% if equipment.unit %}{{ equipment.unit|stringformat:"02d" }}{% endif %}{% else %}-{% endif %}</td></tr>
         <tr><th>{% trans "Purpose" %}:</th><td>{{ equipment.purpose }}</td></tr>
         <tr><th>{% trans "OOB MAC" %}:</th><td>{% if equipment.servermanagement %}{{ equipment.servermanagement.mac }}{% endif %}</td></tr>
         <tr><th>{% trans "OOB Hostname" %}:</th><td>{% if equipment.servermanagement %}<a href="https://{{ equipment.servermanagement.hostname }}">{{ equipment.servermanagement.hostname }}</a>{% endif %}</td></tr>

--- a/servermon/hwdoc/views.py
+++ b/servermon/hwdoc/views.py
@@ -189,11 +189,11 @@ def equipment(request, equipment_id):
     equipment = get_object_or_404(Equipment,pk=equipment_id)
     try:
         equipment.prev = Equipment.objects.filter(rack=equipment.rack, unit__lt=equipment.unit).order_by('-unit')[0]
-    except IndexError:
+    except (IndexError, ValueError):
         equipment.prev = None
     try:
         equipment.next = Equipment.objects.filter(rack=equipment.rack, unit__gt=equipment.unit).order_by('unit')[0]
-    except IndexError:
+    except (IndexError, ValueError):
         equipment.next = None
 
     return render(request, template, { 'equipment': equipment, })


### PR DESCRIPTION
I think I found the only place where attempting to render `equipment.rack` or `equipment.unit` when either of them are `None` borks (and I tidied up equipment view with a "-", like for empty `project`). Let me know if I missed any, and I will add them.
