### PR TITLE
Standardise some fields-when-empty in equipment rendering

### DIFF
--- a/servermon/projectwide/templates/hwdoc_searchresults.html
+++ b/servermon/projectwide/templates/hwdoc_searchresults.html
@@ -28,12 +28,12 @@
           {% endif %}
           {% endif %}
           <td>{{ result.model.vendor }}&nbsp;{{ result.model.name }}</td>
-          <td>{{ result.rack }}</td>
-	  <td>{% for unit in result.model.units %}{{ result.unit|add:unit|add:"-1"|stringformat:"02d" }}<br/>{% endfor %}</td>
+          <td>{% if result.rack %}{{ result.rack }}{% else %}&mdash;{% endif %}</td>
+          <td>{% if result.unit %}{% for unit in result.model.units %}{{ result.unit|add:unit|add:"-1"|stringformat:"02d" }}<br/>{% endfor %}{% else %}&mdash;{% endif %}</td>
           <td class="centered">{% if result.model.rack_front %}<i class="icon-ok-sign"></i>{% else %}&nbsp;{% endif %}</td>
           <td class="centered">{% if result.model.rack_interior %}<i class="icon-ok-sign"></i>{% else %}&nbsp;{% endif %}</td>
           <td class="centered">{% if result.model.rack_back %}<i class="icon-ok-sign"></i>{% else %}&nbsp;{% endif %}</td>
-          <td><a href="https://{{ result.servermanagement.hostname }}">{{ result.servermanagement.hostname }}</a></td>
+          <td>{% if result.servermanagement %}<a href="https://{{ result.servermanagement.hostname }}">{{ result.servermanagement.hostname }}</a>{% else %}&mdash;{% endif %}</td>
           <td>{% if result.allocation %}<a href="{% url "hwdoc.views.project" result.allocation.pk %}">{{ result.allocation.name }}</a>{% else %}&mdash;{% endif %}</td>
           <td>
           {% for ticket in result.ticket_set.all %}


### PR DESCRIPTION
Following previous commit to fix rendering locationless equipment, this standardises rendering of some empty fields (to use &amp;mdash; like other fields do). Checked on local install and rendering looks fine in various views. The only concern might be less obvious side-effects on scripting access, etc.
