### PR TITLE
Remove all occurences of servermon package in imports

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -164,7 +164,7 @@ Then you need to configure the project. Things to pay attention to::
   TEMPLATE_DIRS => at least '/path/to/servermon/templates' needed
   INSTALLED_APPS => (uncomment needed apps). django admin apps are a must for hwdoc
   AUTHENTICATION_BACKENDS = > comment or uncomment
-      'servermon.djangobackends.ldapBackend.ldapBackend',
+      'djangobackends.ldapBackend.ldapBackend',
       depending on whether you want LDAP user authentication or not
 
 Create database tables

--- a/servermon/hwdoc/admin.py
+++ b/servermon/hwdoc/admin.py
@@ -19,7 +19,7 @@ Module configuring Django's admin interface for hwdoc
 '''
 
 from django.contrib import admin
-from servermon.hwdoc.models import *
+from hwdoc.models import *
 from django.utils.translation import ugettext as _
 from keyvalue.admin import KeyValueAdmin
 

--- a/servermon/hwdoc/functions.py
+++ b/servermon/hwdoc/functions.py
@@ -22,9 +22,9 @@ Important function here is search(q) which searches strings or iterables of
 strings in model Equipment.
 '''
 
-from servermon.hwdoc.models import Equipment, ServerManagement
-from servermon.projectwide.functions import canonicalize_mac
-from servermon.puppet.functions import search as puppet_search
+from hwdoc.models import Equipment, ServerManagement
+from projectwide.functions import canonicalize_mac
+from puppet.functions import search as puppet_search
 from django.db.models import Q
 from socket import gethostbyaddr, herror, gaierror, error
 from django.utils.translation import ugettext as _

--- a/servermon/hwdoc/migrations/0001_initial.py
+++ b/servermon/hwdoc/migrations/0001_initial.py
@@ -2,7 +2,7 @@
 
 from south.db import db
 from django.db import models
-from servermon.hwdoc.models import *
+from hwdoc.models import *
 
 class Migration:
 

--- a/servermon/hwdoc/views.py
+++ b/servermon/hwdoc/views.py
@@ -18,11 +18,11 @@
 hwdoc views module
 '''
 
-from servermon.hwdoc.models import Project, EquipmentModel, Equipment, \
+from hwdoc.models import Project, EquipmentModel, Equipment, \
         ServerManagement, Rack, RackRow, Datacenter, RackPosition, Vendor, \
         Ticket
-from servermon.projectwide import functions as projectwide_functions
-from servermon.hwdoc import functions
+from projectwide import functions as projectwide_functions
+from hwdoc import functions
 from django.shortcuts import render
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.db.models import Count

--- a/servermon/projectwide/views.py
+++ b/servermon/projectwide/views.py
@@ -19,11 +19,11 @@
 projectwide views module
 '''
 
-from servermon.puppet import functions as puppet_functions
-from servermon.hwdoc import functions as hwdoc_functions
-from servermon.projectwide import functions as projectwide_functions
-from servermon.puppet.models import Host, Fact, FactValue
-from servermon.updates.models import Package
+from puppet import functions as puppet_functions
+from hwdoc import functions as hwdoc_functions
+from projectwide import functions as projectwide_functions
+from puppet.models import Host, Fact, FactValue
+from updates.models import Package
 from django.shortcuts import render
 from django.core.exceptions import FieldError
 from django.http import HttpResponse

--- a/servermon/puppet/functions.py
+++ b/servermon/puppet/functions.py
@@ -22,7 +22,7 @@ Important function here is search(q) which searches strings or iterables of
 strings in puppet models.
 '''
 
-from servermon.puppet.models import FactValue
+from puppet.models import FactValue
 from django.db import DatabaseError
 from django.db.models import Q
 from django.utils.translation import ugettext as _
@@ -39,7 +39,7 @@ def search(q):
     @return: A QuerySet with results matching all items of q
     '''
 
-    if q is None or len(q) == 0 or 'servermon.puppet' not in settings.INSTALLED_APPS:
+    if q is None or len(q) == 0 or 'puppet' not in settings.INSTALLED_APPS:
         return FactValue.objects.none()
 
     # Working on iterables. However in case we are not given one it is cheaper

--- a/servermon/puppet/views.py
+++ b/servermon/puppet/views.py
@@ -19,7 +19,7 @@
 puppet views module
 '''
 
-from servermon.puppet.models import Host, Fact, FactValue
+from puppet.models import Host, Fact, FactValue
 from django.shortcuts import render
 from django import forms
 from django.contrib.admin.widgets import FilteredSelectMultiple

--- a/servermon/settings.py.dist
+++ b/servermon/settings.py.dist
@@ -77,7 +77,7 @@ TEMPLATE_LOADERS = (
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = global_settings.TEMPLATE_CONTEXT_PROCESSORS + (
-    'servermon.djangobackends.context_processors.installed_apps',
+    'djangobackends.context_processors.installed_apps',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -85,13 +85,13 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'servermon.djangobackends.StripWhitespaceMiddleware.StripWhitespaceMiddleware',
+    'djangobackends.StripWhitespaceMiddleware.StripWhitespaceMiddleware',
 )
 
 ROOT_URLCONF = 'servermon.urls'
 
 AUTHENTICATION_BACKENDS = (
-#    'servermon.djangobackends.ldapBackend.ldapBackend',
+#    'djangobackends.ldapBackend.ldapBackend',
     'django.contrib.auth.backends.ModelBackend',
 )
 

--- a/servermon/updates/models.py
+++ b/servermon/updates/models.py
@@ -20,7 +20,7 @@ updates module's functions documentation. Main models are Package and Update
 
 
 from django.db import models
-from servermon.puppet.models import Host
+from puppet.models import Host
 import re
 
 class Package(models.Model):

--- a/servermon/updates/views.py
+++ b/servermon/updates/views.py
@@ -23,9 +23,9 @@ updates views module
 from django.shortcuts import get_list_or_404, get_object_or_404
 from django.shortcuts import render
 from django.db.models import Count, Sum
-from servermon.puppet.models import Host
-from servermon.updates.models import Package, Update
-from servermon.hwdoc.models import Equipment
+from puppet.models import Host
+from updates.models import Package, Update
+from hwdoc.models import Equipment
 from IPy import IP
 
 def hostlist(request):


### PR DESCRIPTION
Removing all of them in imports/documentation/settings etc. It was an
ugly workaround to avoid the problematic nature of django projects pre
1.4 and we can slowly now drop it
