### PR TITLE
Make S/N search in jira plugin configurable

### DIFF
--- a/servermon/hwdoc/vendor/ticket_jira.py
+++ b/servermon/hwdoc/vendor/ticket_jira.py
@@ -35,7 +35,7 @@ def get_tickets(equipment, closed):
     _projects = settings.JIRA_TICKETING['projects']
     _projects_defaults = settings.JIRA_TICKETING['projects_defaults']
     # construct entire search string so we don't hammer the server repeatedly
-    search_string = 'text ~ "%s"' % equipment.serial
+    search_string = settings.JIRA_TICKETING['search_string'].replace('{}', '"%s"' % equipment.serial)
     if _projects:
         projects = [project.key for project in jira.projects() if project.key in _projects.keys()]
         _first = True

--- a/servermon/settings.py.dist
+++ b/servermon/settings.py.dist
@@ -135,6 +135,7 @@ TICKETING_SYSTEM = 'dummy' # dummy, comments, jira are possible values
 COMMENTS_TICKETING_URL = "http://ticketing.example.com/"
 JIRA_TICKETING = {
     'url': 'http://ticketing.example.com/',
+    'search_string': 'text ~ {}', # {} replaced by double-quoted serial number for search
     'projects': { # empty dict means "all projects"
         'project1': { 'closed_string': 'closed' },
         'project2': { 'closed_string': 'done' },


### PR DESCRIPTION
- search_string is now specified in settings.py
- closes #74
