### PR TITLE
Allow for more than one lead characters in rack/u search

### DIFF
--- a/servermon/hwdoc/functions.py
+++ b/servermon/hwdoc/functions.py
@@ -68,7 +68,7 @@ def search(q):
             mac = canonicalize_mac(key)
             # A heuristic to allow user to filter queries down to the unit level
             # using a simple syntax
-            m = re.search('^(\w?\d\d)[Uu]?(\d\d)$', key)
+            m = re.search('^(\w{1,3}\d\d)[Uu](\d\d)$', key)
             if m:
                 rack = m.group(1)
                 unit = m.group(2)

--- a/servermon/hwdoc/tests.py
+++ b/servermon/hwdoc/tests.py
@@ -171,7 +171,7 @@ class EquipmentTestCase(unittest.TestCase):
         self.assertEqual(search('ALL_EQS').count(), 3)
 
     def test_search_rack_heuristic(self):
-        self.assertEqual(search('%s%s' % (self.server3.rack.name, self.server3.unit)).count(), 1)
+        self.assertEqual(search('%sU%s' % (self.server3.rack.name, self.server3.unit)).count(), 1)
 
     def test_search_serial(self):
         self.assertEqual(search(self.server1.serial)[0].serial, self.server1.serial)


### PR DESCRIPTION
A quick way to search for a machine if you know its rack and u is
provided via the <rackname>U<unit_number> shortcut. This however allowed
for a very specific way to handle rack names which was <letter><two
digits>. Increase the number of letters allowed at the start. This
closes #86