### PR TITLE
Move rack occupation to Equipment model

### DIFF
--- a/servermon/hwdoc/admin.py
+++ b/servermon/hwdoc/admin.py
@@ -267,12 +267,14 @@ class EquipmentAdmin(admin.ModelAdmin):
 
     list_display = ('allocation', 'model', 'serial',
             'rack', 'unit', model_u,
+            'rack_front', 'rack_interior', 'rack_back',
             mgmt_method, mgmt_username, mgmt_password,
             'purpose',)
     list_display_links = ('serial',)
     list_filter = ('model', 'rack',)
     search_fields = ['rack__name', 'unit', 'serial', 'allocation__name']
-    list_editable = ['allocation', 'rack', 'unit']
+    list_editable = ['allocation', 'rack', 'unit',
+            'rack_front', 'rack_interior', 'rack_back',]
     ordering = ('rack', 'unit',)
     inlines = [ ServerManagementInline, KeyValueAdmin ]
     actions = [ shutdown, startup, shutdown_force ]

--- a/servermon/hwdoc/migrations/0026_auto__add_field_equipment_rack_front__add_field_equipment_rack_interio.py
+++ b/servermon/hwdoc/migrations/0026_auto__add_field_equipment_rack_front__add_field_equipment_rack_interio.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Equipment.rack_front'
+        db.add_column('hwdoc_equipment', 'rack_front',
+                      self.gf('django.db.models.fields.BooleanField')(default=True),
+                      keep_default=False)
+
+        # Adding field 'Equipment.rack_interior'
+        db.add_column('hwdoc_equipment', 'rack_interior',
+                      self.gf('django.db.models.fields.BooleanField')(default=True),
+                      keep_default=False)
+
+        # Adding field 'Equipment.rack_back'
+        db.add_column('hwdoc_equipment', 'rack_back',
+                      self.gf('django.db.models.fields.BooleanField')(default=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Equipment.rack_front'
+        db.delete_column('hwdoc_equipment', 'rack_front')
+
+        # Deleting field 'Equipment.rack_interior'
+        db.delete_column('hwdoc_equipment', 'rack_interior')
+
+        # Deleting field 'Equipment.rack_back'
+        db.delete_column('hwdoc_equipment', 'rack_back')
+
+
+    models = {
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'hwdoc.datacenter': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Datacenter'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        'hwdoc.email': {
+            'Meta': {'object_name': 'Email'},
+            'email': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'hwdoc.equipment': {
+            'Meta': {'ordering': "['rack', '-unit']", 'object_name': 'Equipment'},
+            'added': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'allocation': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Project']", 'null': 'True', 'blank': 'True'}),
+            'comments': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.EquipmentModel']"}),
+            'orientation': ('django.db.models.fields.CharField', [], {'default': "'Front'", 'max_length': '10'}),
+            'purpose': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'rack': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Rack']", 'null': 'True', 'blank': 'True'}),
+            'rack_back': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'rack_front': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'rack_interior': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'serial': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'unit': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        'hwdoc.equipmentmodel': {
+            'Meta': {'ordering': "['vendor', 'name']", 'object_name': 'EquipmentModel'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'rack_back': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'rack_front': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'rack_interior': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'u': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'vendor': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Vendor']"})
+        },
+        'hwdoc.person': {
+            'Meta': {'object_name': 'Person'},
+            'emails': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['hwdoc.Email']", 'symmetrical': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'phones': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['hwdoc.Phone']", 'symmetrical': 'False'}),
+            'surname': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.phone': {
+            'Meta': {'object_name': 'Phone'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'number': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.project': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Project'},
+            'contacts': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['hwdoc.Person']", 'through': "orm['hwdoc.Role']", 'symmetrical': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.rack': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Rack'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.RackModel']"}),
+            'mounted_depth': ('django.db.models.fields.PositiveIntegerField', [], {'default': '60', 'max_length': '10'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.rackmodel': {
+            'Meta': {'object_name': 'RackModel'},
+            'height': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '10'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'inrow_ac': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'max_mounting_depth': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '10'}),
+            'min_mounting_depth': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '10'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'vendor': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Vendor']"}),
+            'width': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '10'})
+        },
+        'hwdoc.rackposition': {
+            'Meta': {'ordering': "['position']", 'object_name': 'RackPosition'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'position': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '20'}),
+            'rack': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['hwdoc.Rack']", 'unique': 'True'}),
+            'rr': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.RackRow']"})
+        },
+        'hwdoc.rackrow': {
+            'Meta': {'ordering': "['name']", 'object_name': 'RackRow'},
+            'dc': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Datacenter']", 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.role': {
+            'Meta': {'object_name': 'Role'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Person']"}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Project']"}),
+            'role': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.servermanagement': {
+            'Meta': {'object_name': 'ServerManagement'},
+            'added': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'equipment': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['hwdoc.Equipment']", 'unique': 'True'}),
+            'hostname': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'license': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'mac': ('django.db.models.fields.CharField', [], {'max_length': '17', 'blank': 'True'}),
+            'method': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'raid_license': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'})
+        },
+        'hwdoc.ticket': {
+            'Meta': {'object_name': 'Ticket'},
+            'equipment': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['hwdoc.Equipment']", 'symmetrical': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '20'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '250', 'blank': 'True'})
+        },
+        'hwdoc.vendor': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Vendor'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'keyvalue.key': {
+            'Meta': {'object_name': 'Key'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '150', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'}),
+            'verbose_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'})
+        },
+        'keyvalue.keyvalue': {
+            'Meta': {'unique_together': "(('key', 'owner_content_type', 'owner_object_id'),)", 'object_name': 'KeyValue'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['keyvalue.Key']"}),
+            'owner_content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'owner_object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['hwdoc']

--- a/servermon/hwdoc/migrations/0027_rack_occupation_to_equipment.py
+++ b/servermon/hwdoc/migrations/0027_rack_occupation_to_equipment.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        for model in orm['hwdoc.EquipmentModel'].objects.all():
+            front = model.rack_front
+            interior = model.rack_interior
+            back = model.rack_back
+            model.equipment_set.update(rack_front=front,
+                    rack_interior=interior,
+                    rack_back=back)
+
+    def backwards(self, orm):
+        print 'Backwards migration: Impossible to accurately populate equipment \
+        models rack occupation. Falling back to defaults'
+        orm['hwdoc.EquipmentModel'].objects.update(rack_front=True,
+                rack_interior=True, rack_back=True)
+
+    models = {
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'hwdoc.datacenter': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Datacenter'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        'hwdoc.email': {
+            'Meta': {'object_name': 'Email'},
+            'email': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'hwdoc.equipment': {
+            'Meta': {'ordering': "['rack', '-unit']", 'object_name': 'Equipment'},
+            'added': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'allocation': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Project']", 'null': 'True', 'blank': 'True'}),
+            'comments': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.EquipmentModel']"}),
+            'orientation': ('django.db.models.fields.CharField', [], {'default': "'Front'", 'max_length': '10'}),
+            'purpose': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'rack': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Rack']", 'null': 'True', 'blank': 'True'}),
+            'rack_back': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'rack_front': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'rack_interior': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'serial': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'unit': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        'hwdoc.equipmentmodel': {
+            'Meta': {'ordering': "['vendor', 'name']", 'object_name': 'EquipmentModel'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'rack_back': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'rack_front': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'rack_interior': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'u': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'vendor': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Vendor']"})
+        },
+        'hwdoc.person': {
+            'Meta': {'object_name': 'Person'},
+            'emails': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['hwdoc.Email']", 'symmetrical': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'phones': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['hwdoc.Phone']", 'symmetrical': 'False'}),
+            'surname': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.phone': {
+            'Meta': {'object_name': 'Phone'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'number': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.project': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Project'},
+            'contacts': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['hwdoc.Person']", 'through': "orm['hwdoc.Role']", 'symmetrical': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.rack': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Rack'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.RackModel']"}),
+            'mounted_depth': ('django.db.models.fields.PositiveIntegerField', [], {'default': '60', 'max_length': '10'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.rackmodel': {
+            'Meta': {'object_name': 'RackModel'},
+            'height': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '10'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'inrow_ac': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'max_mounting_depth': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '10'}),
+            'min_mounting_depth': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '10'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'vendor': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Vendor']"}),
+            'width': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '10'})
+        },
+        'hwdoc.rackposition': {
+            'Meta': {'ordering': "['position']", 'object_name': 'RackPosition'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'position': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '20'}),
+            'rack': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['hwdoc.Rack']", 'unique': 'True'}),
+            'rr': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.RackRow']"})
+        },
+        'hwdoc.rackrow': {
+            'Meta': {'ordering': "['name']", 'object_name': 'RackRow'},
+            'dc': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Datacenter']", 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.role': {
+            'Meta': {'object_name': 'Role'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Person']"}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Project']"}),
+            'role': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.servermanagement': {
+            'Meta': {'object_name': 'ServerManagement'},
+            'added': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'equipment': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['hwdoc.Equipment']", 'unique': 'True'}),
+            'hostname': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'license': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'mac': ('django.db.models.fields.CharField', [], {'max_length': '17', 'blank': 'True'}),
+            'method': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'raid_license': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'})
+        },
+        'hwdoc.ticket': {
+            'Meta': {'object_name': 'Ticket'},
+            'equipment': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['hwdoc.Equipment']", 'symmetrical': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '20'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '250', 'blank': 'True'})
+        },
+        'hwdoc.vendor': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Vendor'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'keyvalue.key': {
+            'Meta': {'object_name': 'Key'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '150', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'}),
+            'verbose_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'})
+        },
+        'keyvalue.keyvalue': {
+            'Meta': {'unique_together': "(('key', 'owner_content_type', 'owner_object_id'),)", 'object_name': 'KeyValue'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['keyvalue.Key']"}),
+            'owner_content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'owner_object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['hwdoc']
+    symmetrical = True

--- a/servermon/hwdoc/migrations/0028_auto__del_field_equipmentmodel_rack_front__del_field_equipmentmodel_ra.py
+++ b/servermon/hwdoc/migrations/0028_auto__del_field_equipmentmodel_rack_front__del_field_equipmentmodel_ra.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'EquipmentModel.rack_front'
+        db.delete_column('hwdoc_equipmentmodel', 'rack_front')
+
+        # Deleting field 'EquipmentModel.rack_back'
+        db.delete_column('hwdoc_equipmentmodel', 'rack_back')
+
+        # Deleting field 'EquipmentModel.rack_interior'
+        db.delete_column('hwdoc_equipmentmodel', 'rack_interior')
+
+
+    def backwards(self, orm):
+        # Adding field 'EquipmentModel.rack_front'
+        db.add_column('hwdoc_equipmentmodel', 'rack_front',
+                      self.gf('django.db.models.fields.BooleanField')(default=True),
+                      keep_default=False)
+
+        # Adding field 'EquipmentModel.rack_back'
+        db.add_column('hwdoc_equipmentmodel', 'rack_back',
+                      self.gf('django.db.models.fields.BooleanField')(default=True),
+                      keep_default=False)
+
+        # Adding field 'EquipmentModel.rack_interior'
+        db.add_column('hwdoc_equipmentmodel', 'rack_interior',
+                      self.gf('django.db.models.fields.BooleanField')(default=True),
+                      keep_default=False)
+
+
+    models = {
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'hwdoc.datacenter': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Datacenter'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        'hwdoc.email': {
+            'Meta': {'object_name': 'Email'},
+            'email': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'hwdoc.equipment': {
+            'Meta': {'ordering': "['rack', '-unit']", 'object_name': 'Equipment'},
+            'added': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'allocation': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Project']", 'null': 'True', 'blank': 'True'}),
+            'comments': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.EquipmentModel']"}),
+            'orientation': ('django.db.models.fields.CharField', [], {'default': "'Front'", 'max_length': '10'}),
+            'purpose': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'rack': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Rack']", 'null': 'True', 'blank': 'True'}),
+            'rack_back': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'rack_front': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'rack_interior': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'serial': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'unit': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        'hwdoc.equipmentmodel': {
+            'Meta': {'ordering': "['vendor', 'name']", 'object_name': 'EquipmentModel'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'u': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'vendor': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Vendor']"})
+        },
+        'hwdoc.person': {
+            'Meta': {'object_name': 'Person'},
+            'emails': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['hwdoc.Email']", 'symmetrical': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'phones': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['hwdoc.Phone']", 'symmetrical': 'False'}),
+            'surname': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.phone': {
+            'Meta': {'object_name': 'Phone'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'number': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.project': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Project'},
+            'contacts': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['hwdoc.Person']", 'through': "orm['hwdoc.Role']", 'symmetrical': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.rack': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Rack'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.RackModel']"}),
+            'mounted_depth': ('django.db.models.fields.PositiveIntegerField', [], {'default': '60', 'max_length': '10'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.rackmodel': {
+            'Meta': {'object_name': 'RackModel'},
+            'height': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '10'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'inrow_ac': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'max_mounting_depth': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '10'}),
+            'min_mounting_depth': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '10'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'vendor': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Vendor']"}),
+            'width': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '10'})
+        },
+        'hwdoc.rackposition': {
+            'Meta': {'ordering': "['position']", 'object_name': 'RackPosition'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'position': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '20'}),
+            'rack': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['hwdoc.Rack']", 'unique': 'True'}),
+            'rr': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.RackRow']"})
+        },
+        'hwdoc.rackrow': {
+            'Meta': {'ordering': "['name']", 'object_name': 'RackRow'},
+            'dc': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Datacenter']", 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.role': {
+            'Meta': {'object_name': 'Role'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Person']"}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['hwdoc.Project']"}),
+            'role': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'hwdoc.servermanagement': {
+            'Meta': {'object_name': 'ServerManagement'},
+            'added': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'equipment': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['hwdoc.Equipment']", 'unique': 'True'}),
+            'hostname': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'license': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'mac': ('django.db.models.fields.CharField', [], {'max_length': '17', 'blank': 'True'}),
+            'method': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'raid_license': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'})
+        },
+        'hwdoc.ticket': {
+            'Meta': {'object_name': 'Ticket'},
+            'equipment': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['hwdoc.Equipment']", 'symmetrical': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '20'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '250', 'blank': 'True'})
+        },
+        'hwdoc.vendor': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Vendor'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        'keyvalue.key': {
+            'Meta': {'object_name': 'Key'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '150', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'}),
+            'verbose_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'})
+        },
+        'keyvalue.keyvalue': {
+            'Meta': {'unique_together': "(('key', 'owner_content_type', 'owner_object_id'),)", 'object_name': 'KeyValue'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['keyvalue.Key']"}),
+            'owner_content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'owner_object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['hwdoc']

--- a/servermon/hwdoc/models.py
+++ b/servermon/hwdoc/models.py
@@ -242,9 +242,6 @@ class EquipmentModel(Model):
     '''
 
     u = models.PositiveIntegerField(verbose_name="Us")
-    rack_front = models.BooleanField(default=True)
-    rack_interior = models.BooleanField(default=True)
-    rack_back = models.BooleanField(default=True)
     attrs = generic.GenericRelation(KeyValue,
                                     content_type_field='owner_content_type',
                                     object_id_field='owner_object_id')
@@ -276,6 +273,9 @@ class Equipment(models.Model):
     rack = models.ForeignKey(Rack, null=True, blank=True)
     unit = models.PositiveIntegerField(null=True, blank=True)
     purpose = models.CharField(max_length=80, blank=True)
+    rack_front = models.BooleanField(default=True)
+    rack_interior = models.BooleanField(default=True)
+    rack_back = models.BooleanField(default=True)
     orientation = models.CharField(max_length=10, choices=ORIENTATIONS, default='Front')
     comments = models.TextField(blank=True)
     added = models.DateTimeField(auto_now_add=True)

--- a/servermon/projectwide/templates/hwdoc_searchresults.html
+++ b/servermon/projectwide/templates/hwdoc_searchresults.html
@@ -31,9 +31,9 @@
           <td>{{ result.model.vendor }}&nbsp;{{ result.model.name }}</td>
           <td>{% if result.rack %}{{ result.rack }}{% else %}&mdash;{% endif %}</td>
           <td>{% if result.unit %}{% for unit in result.model.units %}{{ result.unit|add:unit|add:"-1"|stringformat:"02d" }}<br/>{% endfor %}{% else %}&mdash;{% endif %}</td>
-          <td class="centered">{% if result.model.rack_front %}<i class="icon-ok-sign"></i>{% else %}&nbsp;{% endif %}</td>
-          <td class="centered">{% if result.model.rack_interior %}<i class="icon-ok-sign"></i>{% else %}&nbsp;{% endif %}</td>
-          <td class="centered">{% if result.model.rack_back %}<i class="icon-ok-sign"></i>{% else %}&nbsp;{% endif %}</td>
+          <td class="centered">{% if result.rack_front %}<i class="icon-ok-sign"></i>{% else %}&nbsp;{% endif %}</td>
+          <td class="centered">{% if result.rack_interior %}<i class="icon-ok-sign"></i>{% else %}&nbsp;{% endif %}</td>
+          <td class="centered">{% if result.rack_back %}<i class="icon-ok-sign"></i>{% else %}&nbsp;{% endif %}</td>
 	  <td>{{ result.orientation }}</td>
           <td>{% if result.servermanagement %}<a href="https://{{ result.servermanagement.hostname }}">{{ result.servermanagement.hostname }}</a>{% else %}&mdash;{% endif %}</td>
           <td>{% if result.allocation %}<a href="{% url "hwdoc.views.project" result.allocation.pk %}">{{ result.allocation.name }}</a>{% else %}&mdash;{% endif %}</td>


### PR DESCRIPTION
While a way to point out the size of an EquipmentModel and thus the
space it occupies in a Rack horizontally, the current process of setting
the Front/Interior/Back in the Model is wrong. Move them to Equipment
Update the admin interface to allow easy editing of those fields
Update the templates to use the new fields

This closes #80