### PR TITLE
Fix bug in RackModel's unicode function

### DIFF
--- a/servermon/hwdoc/models.py
+++ b/servermon/hwdoc/models.py
@@ -176,7 +176,7 @@ class RackModel(Model):
         verbose_name_plural = _(u'Rack Models')
 
     def __unicode__(self):
-        return "%s %s" % (self.vendor, self.name)
+        return u'%s %s' % (self.vendor, self.name)
 
     @property
     def units(self):


### PR DESCRIPTION
A __unicode__ function is meant to return unicode strings and not simple
strings. This caused a number of issues with displaying non unicode
RackModels.