### PR TITLE
Fix bug in migration can_change_comment of hwdoc

### DIFF
--- a/servermon/hwdoc/migrations/0016_can_change_comment.py
+++ b/servermon/hwdoc/migrations/0016_can_change_comment.py
@@ -9,7 +9,7 @@ class Migration(DataMigration):
     def forwards(self, orm):
         "Write your forwards methods here."
         ct, created = orm['contenttypes.ContentType'].objects.get_or_create(
-            name='equipment', model='equipment', app_label='hwdoc') # model must be lowercase!
+            name='Equipment', model='equipment', app_label='hwdoc') # model must be lowercase!
         perm, created = orm['auth.permission'].objects.get_or_create(
             content_type=ct, codename='can_change_comment', defaults=dict(name=u'Can change comments'))
 


### PR DESCRIPTION
Under Django 1.6 a TransactionManagementError exception would be thrown
when migration 0016_change_change_comment was run. Turns out it was a
simple case error.