### PR TITLE
Lock dependency to pbr to avoid SemVer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@
 from setuptools import setup
 
 setup(
-    setup_requires=['pbr'],
+    setup_requires=['pbr<0.11'],
     pbr=True,
 )


### PR DESCRIPTION
We are not yet doing SemVer so avoid versions of pbr enforcing SemVer.
This is a build dependency so at this point no security considerations
exist