### PR TITLE
pbr version lock in requirements as well

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pbr
+pbr<0.11
 Django>=1.2,<1.5
 south
 whoosh


### PR DESCRIPTION
Commit 81fbe0d locked pbr in setup.py to versions below 0.11 to avoid
the enforced SemVer scheme. Do the same in requirements.txt