### PR TITLE
Bring hwdoc_pass_change command up to par

### DIFF
--- a/servermon/hwdoc/management/commands/hwdoc_pass_change.py
+++ b/servermon/hwdoc/management/commands/hwdoc_pass_change.py
@@ -18,7 +18,7 @@
 Django management command to change a BMC user password
 '''
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy as _l
 
@@ -52,4 +52,8 @@ class Command(BaseCommand):
         '''
 
         options['command'] = 'pass_change'
+        if not options['change_username']:
+            raise CommandError(_('Username to have password changed missing'))
+        if not options['newpass']:
+            raise CommandError(_('New password for username missing'))
         result = _bmc_common.handle(self, *args, **options)

--- a/servermon/hwdoc/models.py
+++ b/servermon/hwdoc/models.py
@@ -395,8 +395,6 @@ class ServerManagement(models.Model):
         Change password for an OOB account
         '''
 
-        if 'change_username' not in kwargs or 'newpass' not in kwargs:
-            raise RuntimeError(_('Username and/or password to be changed not given'))
         return self.__sm__('pass_change', username, password, **kwargs)
 
     def set_settings(self, username=None, password=None, **kwargs):

--- a/servermon/hwdoc/tests.py
+++ b/servermon/hwdoc/tests.py
@@ -501,7 +501,6 @@ class CommandsTestCase(unittest.TestCase):
         call_command('hwdoc_boot_order', self.server2.serial, verbosity=0)
         call_command('hwdoc_get_all_users', self.server2.serial, verbosity=0)
         call_command('hwdoc_license', self.server2.serial, verbosity=0)
-        call_command('hwdoc_pass_change', self.server2.serial, verbosity=0)
         call_command('hwdoc_power_cycle', self.server2.serial, verbosity=0)
         call_command('hwdoc_remove_user', self.server2.serial, verbosity=0)
         call_command('hwdoc_reset', self.server2.serial, verbosity=0)
@@ -517,6 +516,12 @@ class CommandsTestCase(unittest.TestCase):
         call_command('hwdoc_startup', self.server2.serial, verbosity=0)
         # Actually check with verbosity=1
         call_command('hwdoc_startup', self.server2.serial, verbosity=1)
+
+    def test_bmc_command_pass_change(self):
+        call_command('hwdoc_pass_change', self.server2.serial,
+                change_username='username',
+                newpass='password',
+                verbosity=0)
 
     def test_bmc_commands_bad_call(self):
         if DJANGO_VERSION[:2] < (1, 5):
@@ -606,6 +611,22 @@ class CommandsTestCase(unittest.TestCase):
             from compat import monkey_patch_command_execute
             monkey_patch_command_execute('hwdoc_firmware_update')
         call_command('hwdoc_firmware_update', self.server2.serial, verbosity=0)
+
+    def test_bmc_pass_change_no_username(self):
+        if DJANGO_VERSION[:2] < (1, 5):
+            from compat import monkey_patch_command_execute
+            monkey_patch_command_execute('hwdoc_pass_change')
+        call_command('hwdoc_pass_change', self.server2.serial,
+                newpass='password',
+                verbosity=0)
+
+    def test_bmc_pass_change_no_password(self):
+        if DJANGO_VERSION[:2] < (1, 5):
+            from compat import monkey_patch_command_execute
+            monkey_patch_command_execute('hwdoc_pass_change')
+        call_command('hwdoc_pass_change', self.server2.serial,
+                change_username='username',
+                verbosity=0)
 
     def test_populate_tickets(self):
         settings.TICKETING_SYSTEM='dummy'


### PR DESCRIPTION
hwdoc_pass_change had sanity checks in models.py. Move the sanity checks
to the actual command definitions instead. Update tests to reflect that