### PR TITLE
Fix 0016_can_change_comment TransactionManagementError

### DIFF
--- a/servermon/hwdoc/migrations/0016_can_change_comment.py
+++ b/servermon/hwdoc/migrations/0016_can_change_comment.py
@@ -3,20 +3,26 @@ import datetime
 from south.db import db
 from south.v2 import DataMigration
 from django.db import models
+from django.contrib.contenttypes.management import update_contenttypes
+import hwdoc.models
 
 class Migration(DataMigration):
 
     def forwards(self, orm):
         "Write your forwards methods here."
-        ct, created = orm['contenttypes.ContentType'].objects.get_or_create(
+        # We are forcing contenttypes to update themselves instead of waiting on
+        # the django signal post_syncdb because we need them now. Otherwise this
+        # fails and the migration fails
+        update_contenttypes(hwdoc.models, None)
+        ct = orm['contenttypes.ContentType'].objects.get(
             name='Equipment', model='equipment', app_label='hwdoc') # model must be lowercase!
         perm, created = orm['auth.permission'].objects.get_or_create(
             content_type=ct, codename='can_change_comment', defaults=dict(name=u'Can change comments'))
 
     def backwards(self, orm):
         "Write your backwards methods here."
-        ct, created = orm['contenttypes.ContentType'].objects.get_or_create(
-            name='equipment', model='equipment', app_label='hwdoc') # model must be lowercase!
+        ct = orm['contenttypes.ContentType'].objects.get(
+            name='Equipment', model='equipment', app_label='hwdoc') # model must be lowercase!
         perm, created = orm['auth.permission'].objects.get_or_create(
             content_type=ct, codename='can_change_comment')
         perm.delete()


### PR DESCRIPTION
Migration 16 causes TransactionManagementError under Django 1.6, a
previous effort to fix it was done in 58aec5f but it was only half
correct. Drop the anyway faulty get_or_create and replace it with a get
and fix the backwards migration as well