### PR TITLE
Stop using django.conf.urls.defaults in urls.py

### DIFF
--- a/servermon/urls.py
+++ b/servermon/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from django.conf import settings
 
 urlpatterns = patterns('',


### PR DESCRIPTION
Django deprecation info pages clearly state that by django 1.6
django.conf.urls.defaults will have been removed. Since all version we
support already have moved django.conf.urls.defaults functionality to
django.conf.urls, amend urly.py to not import the deprecated class any
longer