### PR TITLE
One more effort to solve Exceptions in hwdoc 0016 migration

### DIFF
--- a/servermon/hwdoc/migrations/0016_can_change_comment.py
+++ b/servermon/hwdoc/migrations/0016_can_change_comment.py
@@ -16,14 +16,18 @@ class Migration(DataMigration):
         update_contenttypes(hwdoc.models, None)
         ct = orm['contenttypes.ContentType'].objects.get(
             name='Equipment', model='equipment', app_label='hwdoc') # model must be lowercase!
-        perm, created = orm['auth.permission'].objects.get_or_create(
-            content_type=ct, codename='can_change_comment', defaults=dict(name=u'Can change comments'))
+        try:
+            perm = orm['auth.permission'].objects.get(
+                content_type=ct, codename='can_change_comment')
+        except Exception:
+            orm['auth.permission'].objects.create(
+                content_type=ct, codename='can_change_comment', name=u'Can change comments')
 
     def backwards(self, orm):
         "Write your backwards methods here."
         ct = orm['contenttypes.ContentType'].objects.get(
             name='Equipment', model='equipment', app_label='hwdoc') # model must be lowercase!
-        perm, created = orm['auth.permission'].objects.get_or_create(
+        perm = orm['auth.permission'].objects.get(
             content_type=ct, codename='can_change_comment')
         perm.delete()
 


### PR DESCRIPTION
Move the last vestiges of get_or_create in migration
0016_can_change_coment to a get call in a try-except block that will be
followed up by a create. The reason for this is that SQLite and
Django1.6 with the new transaction management system do not go along
very well causing errors.