### PR TITLE
Change a forgotten mimetype parameter to content_type

### DIFF
--- a/servermon/projectwide/views.py
+++ b/servermon/projectwide/views.py
@@ -196,4 +196,4 @@ def suggest(request):
 
     response = json.dumps(resp)
 
-    return HttpResponse(response, mimetype = 'application/x-suggestions+json')
+    return HttpResponse(response, content_type = 'application/x-suggestions+json')


### PR DESCRIPTION
For a long time now, mimetype argument to HttpResponse was heading for
deprecation. It has been removed on Django 1.7. Change the one remaining
instance of it to content_type