### PR TITLE
Wrap hwdoc_populate_tickets in a transaction

### DIFF
--- a/servermon/hwdoc/management/commands/hwdoc_populate_tickets.py
+++ b/servermon/hwdoc/management/commands/hwdoc_populate_tickets.py
@@ -21,6 +21,7 @@ Django management command to populate tickets associated with Equipment
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy as _l
+from django.db import transaction
 
 from hwdoc.functions import populate_tickets, search
 
@@ -41,6 +42,7 @@ class Command(BaseCommand):
                     help=_l('Populated closed tickets as well')),
                     )
 
+    @transaction.commit_on_success
     def handle(self, *args, **options):
         '''
         Handle command


### PR DESCRIPTION
In #66, there was some concern about cron commands running while the
entire project is in maintenance mode and possibly DDL commands are run
on the database. To avoid such issues as well as avoiding
inconsistencies, make_updates has for a long time been wrapped in a
commin_on_success decorator. Wrap populate_tickets in the same decorator
as well. This closes #66