### PR TITLE
Avoid using wheel in tox tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ setenv = VIRTUAL_ENV={envdir}
          LANGUAGE=en_US:en
          LC_ALL=C
 skip_install = True
-install_command = pip install {opts} {packages}
+install_command = pip install --no-use-wheel {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
        django13: Django>=1.3,<1.4
        django14: Django>=1.4,<1.5


### PR DESCRIPTION
This seems to trigger a weird scenario in Django 1.3 and 1.4 where unit
tests for django admin are failing. Skip using it. Do note that it will
still be installed though