### PR TITLE
Add STATIC_URL setting

### DIFF
--- a/servermon/settings.py.dist
+++ b/servermon/settings.py.dist
@@ -57,6 +57,10 @@ MEDIA_ROOT = here('static')
 # Examples: "http://media.lawrence.com", "http://example.com/media/"
 MEDIA_URL = '/static/'
 
+# Abuse STATIC_URL for now without having collectstatic and by having already
+# provisioned an admin directory under static
+STATIC_URL = '/static/'
+
 # URL prefix for admin media -- CSS, JavaScript and images. Make sure to use a
 # trailing slash.
 # Examples: "http://foo.com/media/", "/media/".


### PR DESCRIPTION
STATIC_URL setting is used in django 1.3+ to serve the static files.
Abuse for now STATIC_URL and set it at the same as MEDIA_URL. This
allows the admin views to render since we have populated already an
admin directory in /static/