### PR TITLE
Silence the erroneous 1_6.W001 check

### DIFF
--- a/servermon/settings.py.dist
+++ b/servermon/settings.py.dist
@@ -168,6 +168,10 @@ SOUTH_MIGRATION_MODULES = {
     'updates': 'updates.south_migrations',
 }
 
+# Silence the erroneous 1_6.W001 check. It was removed in
+# https://code.djangoproject.com/ticket/23469 anyway
+SILENCED_SYSTEM_CHECKS = ['1_6.W001']
+
 # Django extensions (apt-get install python-django-extensions)
 try:
     import django_extensions


### PR DESCRIPTION
Django developers removed the check anyway and it is creating false
positives. Silence the check