### PR TITLE
tox: enable code coverage generation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-; flake8 includes both pep8 and pyflakes :]
-envlist = doc,django{13,14,15,16,17}
+envlist = doc,django{13,14,15,16,17},coverage
 
 ;
 ; test environnements
@@ -23,20 +22,17 @@ commands = cp servermon/settings.py.dist servermon/settings.py
            rm -f servermon-test.db
            python servermon/manage.py syncdb --noinput --settings=settings-test
            python servermon/manage.py migrate --noinput --settings=settings-test
-           python servermon/manage.py test --noinput --settings=settings-test
+           python -m coverage run --parallel-mode --source=servermon servermon/manage.py test --noinput --settings=settings-test
 whitelist_externals = cp
                       rm
 
+; flake8 includes both pep8 and pyflakes
 [testenv:flake8]
 commands = flake8
 
 [testenv:coverage]
-commands = cp servermon/settings.py.dist servermon/settings.py
-           python servermon/manage.py syncdb --noinput --settings=settings-test
-           python servermon/manage.py migrate --noinput --settings=settings-test
-           python -m coverage run --source=servermon servermon/manage.py test --noinput --settings=settings-test
+commands = python -m coverage combine
            python -m coverage html
-whitelist_externals = cp
 
 [testenv:doc]
 commands = mkdir -p docbuild/api


### PR DESCRIPTION
Enable code coverage generation in standard tox runs. Use coverage's
parallel mode to gather code coverage reports from all django
environments and combine them in the coverage step to gather more
accurate data.