### PR TITLE
Support dry_run for dev_fixtures command

### DIFF
--- a/servermon/projectwide/management/commands/dev_fixtures.py
+++ b/servermon/projectwide/management/commands/dev_fixtures.py
@@ -53,6 +53,11 @@ class Command(BaseCommand):
                         dest='yes_force_run',
                         default=False,
                         help=_l('Required. Force the run to happen')),
+                    make_option('-n', '--dry_run',
+                        action='store_true',
+                        dest='dry_run',
+                        default=False,
+                        help=_l('Dry run, mostly for testing the generation itself')),
                     make_option('--fact_number',
                         action='store',
                         type='int',
@@ -207,6 +212,10 @@ class Command(BaseCommand):
             self.create_hwdoc_equipments(options['equipment_number'])
             # Keep stdout
             stdout = sys.stdout
+            if dry_run:
+                transaction.rollback()
+                return
+
             for i in ['puppet', 'updates', 'hwdoc']:
                 # Note: The with construct does not play well with this as the
                 # resource will be closed when calling the function

--- a/servermon/projectwide/tests.py
+++ b/servermon/projectwide/tests.py
@@ -18,6 +18,7 @@
 Unit tests for projectwide package
 '''
 
+import os
 from django import VERSION as DJANGO_VERSION
 import ldap
 from mockldap import MockLdap
@@ -189,4 +190,4 @@ class CommandsTestCase(unittest.TestCase):
 
     #Tests start here
     def test_bmc_commands(self):
-        call_command('dev_fixtures', yes_force_run=True)
+        call_command('dev_fixtures', yes_force_run=True, dry_run=True)


### PR DESCRIPTION
Allow the dev_fixtures command to do a dry run, aka not generate the
actual sampledata.json files. This allows for cleaner testing of the
command. Amend the tests to use the new parameter