### PR TITLE
hwdoc: Add a Storage model

### DIFF
--- a/servermon/hwdoc/admin.py
+++ b/servermon/hwdoc/admin.py
@@ -88,6 +88,7 @@ admin.site.register(Project, ProjectAdmin)
 admin.site.register(Vendor)
 admin.site.register(RackModel)
 admin.site.register(Ticket)
+admin.site.register(Storage)
 
 class DatacenterAdmin(admin.ModelAdmin):
     '''
@@ -285,10 +286,14 @@ class EquipmentAdmin(admin.ModelAdmin):
             cleaned_data = super(self.__class__, self).clean()
             rack = cleaned_data['rack']
             unit = cleaned_data['unit']
+            storage = cleaned_data['storage']
             if rack and not unit:
                 raise forms.ValidationError(_('You have forgotten about unit'))
             if unit and not rack:
                 raise forms.ValidationError(_('You have forgotten about rack'))
+            if storage and rack:
+                raise forms.ValidationError(_('An equipment can not be both \
+                    mounted on a Rack and stored in Storage'))
             return cleaned_data
 
         form = super(EquipmentAdmin, self).get_form(request, obj, **kwargs)

--- a/servermon/hwdoc/models.py
+++ b/servermon/hwdoc/models.py
@@ -235,6 +235,22 @@ class RackRow(models.Model):
     def __unicode__(self):
         return u'%s in %s' % (self.name, self.dc)
 
+class Storage(models.Model):
+    '''
+    Datacenter may have storage facilities
+    '''
+
+    name = models.CharField(max_length=80, unique=True)
+    dc = models.ForeignKey(Datacenter)
+
+    class Meta:
+        ordering = ['name', ]
+        verbose_name = _(u'Storage')
+        verbose_name_plural = _(u'Storages')
+
+    def __unicode__(self):
+        return u'%s in %s' % (self.name, self.dc)
+
 class RackPosition(models.Model):
     '''
     Racks can be positioned in a RackRow
@@ -297,6 +313,7 @@ class Equipment(models.Model):
     rack_interior = models.BooleanField(default=True)
     rack_back = models.BooleanField(default=True)
     orientation = models.CharField(max_length=10, choices=ORIENTATIONS, default='Front')
+    storage = models.ForeignKey(Storage, null=True, blank=True)
     comments = models.TextField(blank=True)
     added = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)

--- a/servermon/hwdoc/south_migrations/0029_auto__add_storage__add_field_equipment_storage.py
+++ b/servermon/hwdoc/south_migrations/0029_auto__add_storage__add_field_equipment_storage.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Storage'
+        db.create_table(u'hwdoc_storage', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(unique=True, max_length=80)),
+            ('dc', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['hwdoc.Datacenter'])),
+        ))
+        db.send_create_signal(u'hwdoc', ['Storage'])
+
+        # Adding field 'Equipment.storage'
+        db.add_column(u'hwdoc_equipment', 'storage',
+                      self.gf('django.db.models.fields.related.ForeignKey')(to=orm['hwdoc.Storage'], null=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting model 'Storage'
+        db.delete_table(u'hwdoc_storage')
+
+        # Deleting field 'Equipment.storage'
+        db.delete_column(u'hwdoc_equipment', 'storage_id')
+
+
+    models = {
+        u'hwdoc.datacenter': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Datacenter'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        u'hwdoc.email': {
+            'Meta': {'object_name': 'Email'},
+            'email': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'hwdoc.equipment': {
+            'Meta': {'ordering': "['rack', '-unit']", 'object_name': 'Equipment'},
+            'added': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'allocation': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['hwdoc.Project']", 'null': 'True', 'blank': 'True'}),
+            'comments': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['hwdoc.EquipmentModel']"}),
+            'orientation': ('django.db.models.fields.CharField', [], {'default': "'Front'", 'max_length': '10'}),
+            'purpose': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'rack': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['hwdoc.Rack']", 'null': 'True', 'blank': 'True'}),
+            'rack_back': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'rack_front': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'rack_interior': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'serial': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'storage': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['hwdoc.Storage']", 'null': 'True', 'blank': 'True'}),
+            'unit': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'hwdoc.equipmentmodel': {
+            'Meta': {'ordering': "['vendor', 'name']", 'object_name': 'EquipmentModel'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'u': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'vendor': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['hwdoc.Vendor']"})
+        },
+        u'hwdoc.person': {
+            'Meta': {'object_name': 'Person'},
+            'emails': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['hwdoc.Email']", 'symmetrical': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'phones': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['hwdoc.Phone']", 'symmetrical': 'False'}),
+            'surname': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'hwdoc.phone': {
+            'Meta': {'object_name': 'Phone'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'number': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'hwdoc.project': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Project'},
+            'contacts': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['hwdoc.Person']", 'through': u"orm['hwdoc.Role']", 'symmetrical': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'hwdoc.rack': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Rack'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['hwdoc.RackModel']"}),
+            'mounted_depth': ('django.db.models.fields.PositiveIntegerField', [], {'default': '60', 'max_length': '10'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'hwdoc.rackmodel': {
+            'Meta': {'object_name': 'RackModel'},
+            'height': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '10'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'inrow_ac': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'max_mounting_depth': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '10'}),
+            'min_mounting_depth': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '10'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'vendor': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['hwdoc.Vendor']"}),
+            'width': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '10'})
+        },
+        u'hwdoc.rackposition': {
+            'Meta': {'ordering': "['position']", 'object_name': 'RackPosition'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'position': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '20'}),
+            'rack': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['hwdoc.Rack']", 'unique': 'True'}),
+            'rr': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['hwdoc.RackRow']"})
+        },
+        u'hwdoc.rackrow': {
+            'Meta': {'ordering': "['name']", 'object_name': 'RackRow'},
+            'dc': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['hwdoc.Datacenter']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'hwdoc.role': {
+            'Meta': {'object_name': 'Role'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['hwdoc.Person']"}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['hwdoc.Project']"}),
+            'role': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        },
+        u'hwdoc.servermanagement': {
+            'Meta': {'object_name': 'ServerManagement'},
+            'added': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'equipment': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['hwdoc.Equipment']", 'unique': 'True'}),
+            'hostname': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'license': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'mac': ('django.db.models.fields.CharField', [], {'max_length': '17', 'blank': 'True'}),
+            'method': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'raid_license': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'})
+        },
+        u'hwdoc.storage': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Storage'},
+            'dc': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['hwdoc.Datacenter']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'})
+        },
+        u'hwdoc.ticket': {
+            'Meta': {'object_name': 'Ticket'},
+            'equipment': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['hwdoc.Equipment']", 'symmetrical': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '20'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '250', 'blank': 'True'})
+        },
+        u'hwdoc.vendor': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Vendor'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80'})
+        }
+    }
+
+    complete_apps = ['hwdoc']

--- a/servermon/hwdoc/templates/datacenter.html
+++ b/servermon/hwdoc/templates/datacenter.html
@@ -29,6 +29,18 @@
       {% endfor %}
       </tbody>
     </table>
+    <table class="table table-striped table-condensed">
+      <tbody>
+      <tr>
+        <th>{% trans "Storage Facilities" %}</th>
+      </tr>
+      {% for storage in storages %}
+      <tr>
+        <td><a href="{% url "hwdoc.views.storage" storage.pk %}">{{ storage.name }}</a></td>
+      </tr>
+      {% endfor %}
+      </tbody>
+    </table>
   </div>
   <div class="span2"></div>
 </div>

--- a/servermon/hwdoc/templates/storage.html
+++ b/servermon/hwdoc/templates/storage.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% load url from future %}
+
+{% block heading %}{{ storage }}{% endblock %}
+{% block content %}
+<div class="row-fluid text-center">
+  <div id="storage" class="span8 offset2">
+    <h3>{% trans "Storage Info" %}</h3>
+    <table class="table table-striped table-condensed">
+      <tbody>
+        <tr><th>{% trans "Name" %}:</th><td>{{ datacenter.name }}</td></tr>
+      </tbody>
+    </table>
+    <h3>{% trans "Stored Equipment Info" %}</h3>
+    {% with equipments as results %}
+    {% include "hwdoc_searchresults.html" %}
+    {% endwith %}
+  </div>
+  <div class="span2"></div>
+</div>
+{% endblock %}

--- a/servermon/hwdoc/tests.py
+++ b/servermon/hwdoc/tests.py
@@ -26,7 +26,7 @@ from django.conf import settings
 from django.contrib.auth.models import User, Permission
 from hwdoc.models import Vendor, EquipmentModel, Equipment, \
     ServerManagement, Project, Rack, RackPosition, RackModel, RackRow, \
-    Datacenter, Ticket, \
+    Datacenter, Storage, Ticket, \
     Email, Phone, Person, Project, Role
 from hwdoc.functions import search, populate_tickets
 from projectwide.functions import get_search_terms
@@ -65,6 +65,8 @@ class EquipmentTestCase(unittest.TestCase):
         self.rack = Rack.objects.create(model=self.rackmodel, name='testrack')
         self.rack2 = Rack.objects.create(model=self.rackmodel, name='R02')
         RackPosition.objects.create(rack=self.rack, rr=self.rackrow, position=10)
+        self.storage = Storage.objects.create(name='Test DCs storage',
+                dc=self.dc)
 
         self.server1 = Equipment.objects.create(
                                 model = self.model1,
@@ -128,6 +130,7 @@ class EquipmentTestCase(unittest.TestCase):
         Rack.objects.all().delete()
         RackRow.objects.all().delete()
         Datacenter.objects.all().delete()
+        Storage.objects.all().delete()
 
     # Tests start here
     def test_if_servers_in_same_rack(self):
@@ -274,6 +277,8 @@ class ViewsTestCase(unittest.TestCase):
         self.rackrow = RackRow.objects.create(name='1st rackrow', dc=self.dc)
         RackPosition.objects.create(rack=self.rack, rr=self.rackrow, position=10)
         self.racknotinrow = Rack.objects.create(model=self.rackmodel, name='racknotinrow')
+        self.storage = Storage.objects.create(name='Test DCs storage',
+                dc=self.dc)
 
         self.server_unallocated = Equipment.objects.create(
                                 model = self.model,
@@ -320,6 +325,7 @@ class ViewsTestCase(unittest.TestCase):
         Rack.objects.all().delete()
         RackRow.objects.all().delete()
         Datacenter.objects.all().delete()
+        Storage.objects.all().delete()
 
     def test_search_get(self):
         c = Client()

--- a/servermon/hwdoc/urls.py
+++ b/servermon/hwdoc/urls.py
@@ -22,5 +22,6 @@ urlpatterns = patterns('hwdoc.views',
             (r'^rack/(?P<rack_id>[\d]+)/$', 'rack'),
             (r'^rackrow/(?P<rackrow_id>[\d]+)/$', 'rackrow'),
             (r'^datacenter/(?P<datacenter_id>[\d]+)/$', 'datacenter'),
+            (r'^storage/(?P<storage_id>[\d]+)/$', 'storage'),
             )
 

--- a/servermon/hwdoc/views.py
+++ b/servermon/hwdoc/views.py
@@ -20,7 +20,7 @@ hwdoc views module
 
 from hwdoc.models import Project, EquipmentModel, Equipment, \
         ServerManagement, Rack, RackRow, Datacenter, RackPosition, Vendor, \
-        Ticket
+        Ticket, Storage
 from projectwide import functions as projectwide_functions
 from hwdoc import functions
 from django.shortcuts import render
@@ -310,6 +310,7 @@ def datacenter(request, datacenter_id):
 
     datacenter = get_object_or_404(Datacenter, pk=datacenter_id)
     rackrows = datacenter.rackrow_set.all()
+    storages = datacenter.storage_set.all()
     for rackrow in rackrows:
         equipments = Equipment.objects.filter(rack__rackposition__rr__name=rackrow.name)
         equipments = equipments.exclude(ticket__isnull=True)
@@ -318,5 +319,23 @@ def datacenter(request, datacenter_id):
     return render(request, template, {
         'datacenter': datacenter,
         'rackrows': rackrows,
+        'storages': storages,
         })
 
+def storage(request, storage_id):
+    '''
+    Storage view. It should display all non-authenticated user viewable data
+
+    @type   request: HTTPRequest
+    @param  request: Django HTTPRequest object
+    @rtype: HTTPResponse
+    @return: HTTPResponse object rendering corresponding HTML
+    '''
+
+    template = 'storage.html'
+
+    storage = get_object_or_404(Storage, pk=storage_id)
+    equipments = storage.equipment_set.all()
+    return render(request, template, {
+            'equipments': {'hwdoc': equipments},
+        })

--- a/servermon/templates/base.html
+++ b/servermon/templates/base.html
@@ -63,7 +63,7 @@
 		    <li><a href="{% url "hwdoc.views.unallocated_equipment" %}">{% trans "Unallocated Equipment" %}</a></li>
 		    <li><a href="{% url "hwdoc.views.ticketed_equipment" %}">{% trans "Equipment with tickets" %}</a></li>
 		    <li><a href="{% url "hwdoc.views.commented_equipment" %}">{% trans "Equipment with comments" %}</a></li>
-		    <li><a href="{% url "hwdoc.views.unracked_equipment" %}">{% trans "Unracked Equipment" %}</a></li>
+		    <li><a href="{% url "hwdoc.views.unracked_equipment" %}">{% trans "Stored/Unracked Equipment" %}</a></li>
                   </ul>
                 </li>
 		<li id="datacenters" class="dropdown-submenu"><a href="#" class="hwdocfetchable" data-get="{% url "hwdoc.views.subnav" "datacenters" %}">{% trans "Datacenters" %}</a>


### PR DESCRIPTION
Meant to represent the capability of a Datacenter to have one or more
storage facilities. Update Datacenter views to reflect that and add a
view to display storage facilities. Add tests for the new model and
views