### PR TITLE
Fix migration 0029 failure on older south versions

### DIFF
--- a/servermon/hwdoc/south_migrations/0029_auto__add_storage__add_field_equipment_storage.py
+++ b/servermon/hwdoc/south_migrations/0029_auto__add_storage__add_field_equipment_storage.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from south.utils import datetime_utils as datetime
+import datetime
 from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models


### PR DESCRIPTION
Migration 0029 for hwdoc was generated with a newer south version
(1.0.1) that has datetime_utils imported as datetime. Undo that specific
import and use the previous south behavior of importing datetime