### PR TITLE
Pin mock version requirement

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,5 +7,6 @@ flake8
 epydoc
 sphinx
 pysqlite
+mock<1.1.0
 mockldap
 coverage


### PR DESCRIPTION
Seems like mock 1.3.0 requires pbr 0.11 which we avoid for now on
purpose. For now pin mock versions to before 1.3.0 to avoid the issue.