### PR TITLE
Enable coveralls.io code coverage reporting

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,3 +10,4 @@ pysqlite
 mock<1.1.0
 mockldap
 coverage
+coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ setenv = VIRTUAL_ENV={envdir}
          LANG=en_US.UTF-8
          LANGUAGE=en_US:en
          LC_ALL=C
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 skip_install = True
 install_command = pip install --no-use-wheel {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
@@ -33,6 +34,7 @@ commands = flake8
 [testenv:coverage]
 commands = python -m coverage combine
            python -m coverage html
+           coveralls
 
 [testenv:doc]
 commands = mkdir -p docbuild/api


### PR DESCRIPTION
Use the coveralls module to enable coveralls.io integration. Pass the
necessary information to tox from travis-ci