### PR TITLE
Remove Django < 1.3 casings

### DIFF
--- a/servermon/hwdoc/tests.py
+++ b/servermon/hwdoc/tests.py
@@ -20,6 +20,7 @@ Unit tests for hwdoc package
 
 from django import VERSION as DJANGO_VERSION
 
+from django.utils import unittest
 from django.test.client import Client
 from django.core.management import call_command, CommandError
 from django.conf import settings
@@ -32,10 +33,6 @@ from hwdoc.functions import search, populate_tickets
 from projectwide.functions import get_search_terms
 
 import os
-if DJANGO_VERSION[:2] >= (1, 3):
-    from django.utils import unittest
-else:
-    import unittest
 
 
 class EquipmentTestCase(unittest.TestCase):

--- a/servermon/keyvalue/tests.py
+++ b/servermon/keyvalue/tests.py
@@ -18,15 +18,10 @@
 Unit tests for keyvalue package
 '''
 
-from django import VERSION as DJANGO_VERSION
 from django.contrib.auth.models import User, Permission
 from django.test.client import Client
+from django.utils import unittest
 from keyvalue.models import Key, KeyValue
-
-if DJANGO_VERSION[:2] >= (1, 3):
-    from django.utils import unittest
-else:
-    import unittest
 
 
 class KeyTestCase(unittest.TestCase):

--- a/servermon/projectwide/tests.py
+++ b/servermon/projectwide/tests.py
@@ -19,19 +19,15 @@ Unit tests for projectwide package
 '''
 
 import os
-from django import VERSION as DJANGO_VERSION
 import ldap
 from mockldap import MockLdap
 
-if DJANGO_VERSION[:2] >= (1, 3):
-    from django.utils import unittest
-else:
-    import unittest
+from django.utils import unittest
+from django.test.client import Client
 from django.core.management import call_command
 
 from puppet.models import Host, Resource, FactValue, Fact
 from projectwide.functions import get_search_terms, canonicalize_mac
-from django.test.client import Client
 
 # The following is an ugly hack for unit tests to work
 # We force managed the unmanaged models so that tables will be created

--- a/servermon/puppet/tests.py
+++ b/servermon/puppet/tests.py
@@ -18,14 +18,8 @@
 Unit tests for puppet package
 '''
 
-from django import VERSION as DJANGO_VERSION
-
-if DJANGO_VERSION[:2] >= (1, 3):
-    from django.utils import unittest
-else:
-    import unittest
-
 from django.test.client import Client
+from django.utils import unittest
 from puppet.models import Fact, Host, FactValue, ParamNames, ParamValues, PuppetTags, \
                     ResourceTags, SourceFile, Resource
 

--- a/servermon/updates/tests.py
+++ b/servermon/updates/tests.py
@@ -18,17 +18,12 @@
 Unit tests for updates package
 '''
 
-from django import VERSION as DJANGO_VERSION
-
-if DJANGO_VERSION[:2] >= (1, 3):
-    from django.utils import unittest
-else:
-    import unittest
+from django.test.client import Client
+from django.utils import unittest
+from django.core.management import call_command
 
 from puppet.models import Host, Resource, FactValue, Fact
 from updates.models import Package, Update
-from django.test.client import Client
-from django.core.management import call_command
 
 # The following is an ugly hack for unit tests to work
 # We force managed the unmanaged models so that tables will be created


### PR DESCRIPTION
We no longer support Django < 1.3 so remove any leftover casing for
anything like that