### PR TITLE
short circuit readthedocs.org integration

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,0 +1,5 @@
+pbr<0.11
+Django>=1.3,<1.5
+south
+whoosh
+ipy


### PR DESCRIPTION
Seems like readthedocs.org tries to now unconditionally install
requirements.txt unless instructed with a different file. This
unfortunately fails due to readthedocs.org not wanting to compile C
modules like python-ldap which we use. Using a doc-requirements.txt
bypass this behaviour and configure it in readthedocs.org