### PR TITLE
coverage: try to omit some files from coverage checks

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+parallel = True
+source = servermon
+omit =
+	servermon/hwdoc/vendor/bmc_ilo3.py
+	servermon/hwdoc/vendor/ticket_jira.py

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands = cp servermon/settings.py.dist servermon/settings.py
            rm -f servermon-test.db
            python servermon/manage.py syncdb --noinput --settings=settings-test
            python servermon/manage.py migrate --noinput --settings=settings-test
-           python -m coverage run --parallel-mode --source=servermon servermon/manage.py test --noinput --settings=settings-test
+           python -m coverage run servermon/manage.py test --noinput --settings=settings-test
 whitelist_externals = cp
                       rm
 


### PR DESCRIPTION
Avoid reporting the coverage of some vendor specific plugins for bmc and
ticket modules. These are generally difficult to test right now and not
used very much so will skip them for now