### PR TITLE
coverage: add apt2xml to omitted files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,3 +4,4 @@ source = servermon
 omit =
 	servermon/hwdoc/vendor/bmc_ilo3.py
 	servermon/hwdoc/vendor/ticket_jira.py
+	servermon/apt2xml.py


### PR DESCRIPTION
We are not testing apt2xml or are ever going to test it. Omit it from
code coverage reports. This refs #145 