### PR TITLE
tests: Reorganize search tests

### DIFF
--- a/servermon/hwdoc/tests.py
+++ b/servermon/hwdoc/tests.py
@@ -324,27 +324,6 @@ class ViewsTestCase(unittest.TestCase):
         Datacenter.objects.all().delete()
         Storage.objects.all().delete()
 
-    def test_search_get(self):
-        c = Client()
-        data = ['', 'dummy', '562346', 'R5U21', 'UI2354']
-        for d in data:
-            response = c.get('/search/', {'q': d})
-            self.assertEqual(response.status_code, 200)
-
-    def test_search_get_txt(self):
-        c = Client()
-        data = ['', 'dummy', '562346', 'R5U21', 'UI2354']
-        for d in data:
-            response = c.get('/search/', {'q': d, 'txt': 'yes'})
-            self.assertEqual(response.status_code, 200)
-
-    def test_free_text_search_post(self):
-        c = Client()
-        strings = [ 'this is a dummy string', '0.0', '.example.tld' ]
-        for s in strings:
-            response = c.post('/search/', {'qarea': s})
-            self.assertEqual(response.status_code, 200)
-
     def test_index(self):
         c = Client()
         response = c.get('/hwdoc/')

--- a/servermon/projectwide/tests.py
+++ b/servermon/projectwide/tests.py
@@ -84,13 +84,37 @@ class ProjectWideViewsTestCase(unittest.TestCase):
 
     def test_correct_search(self):
         c = Client()
-        response = c.post('/search/', {'q': self.host1.name})
+        response = c.get('/search/', {'q': self.host1.name})
+        self.assertEqual(response.status_code, 200)
+
+    def test_correct_search_txt(self):
+        c = Client()
+        response = c.get('/search/', {'q': self.host1.name, 'txt': 'yes'})
+        self.assertEqual(response.status_code, 200)
+
+    def test_correct_search_csv(self):
+        c = Client()
+        response = c.get('/search/', {'q': self.host1.name, 'csv': 'yes'})
         self.assertEqual(response.status_code, 200)
 
     def test_advanced_search(self):
         c = Client()
         response = c.post('/advancedsearch/')
         self.assertEqual(response.status_code, 200)
+
+    def test_random_search_get(self):
+        c = Client()
+        data = ['', 'dummy', '562346', 'R5U21', 'UI2354']
+        for d in data:
+            response = c.get('/search/', {'q': d})
+            self.assertEqual(response.status_code, 200)
+
+    def test_free_text_search_post(self):
+        c = Client()
+        strings = [ 'this is a dummy string', '0.0', '.example.tld' ]
+        for s in strings:
+            response = c.post('/search/', {'qarea': s})
+            self.assertEqual(response.status_code, 200)
 
     def test_opensearch(self):
         c = Client()


### PR DESCRIPTION
search view tests should be under the corresponding app. That is
projectwide and not hwdoc. Move and amend the tests correspondingly as
well as add a new csv search