### PR TITLE
Run more tests for dev_fixtures django command

### DIFF
--- a/servermon/projectwide/tests.py
+++ b/servermon/projectwide/tests.py
@@ -187,3 +187,5 @@ class CommandsTestCase(unittest.TestCase):
     #Tests start here
     def test_bmc_commands(self):
         call_command('dev_fixtures', yes_force_run=True, dry_run=True)
+        call_command('dev_fixtures', yes_force_run=True, dry_run=False)
+        call_command('dev_fixtures', yes_force_run=False, dry_run=True)


### PR DESCRIPTION
Some codepaths were not reached before due to the way the django
management command dev_fixtures was called. Call another 2 instances of
the command to amend for that