### PR TITLE
Update WSGI setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.pyc
 /dist/
-/servermon/settings.py
+servermon/servermon/settings.py
 .*.swp
 .venv
 /docbuild

--- a/doc/examples/README
+++ b/doc/examples/README
@@ -1,0 +1,7 @@
+Application server examples
+===========================
+
+This directory holds various configuration example for app servers,
+known to work. Targeted specifically at Debian based distributions, but
+PRs are welcome to support other distros
+

--- a/doc/examples/gunicorn.conf.example.Debian
+++ b/doc/examples/gunicorn.conf.example.Debian
@@ -1,10 +1,10 @@
 CONFIG = {
     'mode': 'wsgi',
-    'working_dir': '/path/to/dir/servermon',
+    'working_dir': '/path/to/servermon',
     'args': (
         '--bind=0.0.0.0:8090',
         '--workers=4',
         '--timeout=10',
-	'wsgi',
+        'wsgi:application',
     ),
 }

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -124,8 +124,8 @@ separate db from Puppet the above instructions must be modified
 accordingly (having servermon on a separate db could be useful if, for
 example, you are replicating the puppet db from a master elsewhere).
 
-Configuring urls.py
-+++++++++++++++++++
+Configuring app servers
++++++++++++++++++++++++
 
 **Mandatory**.
 
@@ -159,7 +159,8 @@ Configuring settings.py
 
 First you need to copy settings.py.dist::
 
-  $ cp /path/to/servermon
+  $ cp /path/to/servermon/
+  $ cd servermon/servermon
   $ cp settings.py.dist settings.py
 
 Then you need to configure the project. Things to pay attention to::

--- a/servermon/servermon/settings.py.dist
+++ b/servermon/servermon/settings.py.dist
@@ -4,6 +4,7 @@ from django.conf import global_settings
 from django import VERSION as DJANGO_VERSION
 here = lambda x: os.path.join(os.path.abspath(os.path.dirname(__file__)), x)
 
+
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
@@ -165,6 +166,11 @@ LDAP_AUTH_IS_STAFF = True
 # South
 if DJANGO_VERSION[:2] < (1, 7):
     INSTALLED_APPS = INSTALLED_APPS + ('south',)
+
+# Use the old pre 1.6 testrunner
+if DJANGO_VERSION[:2] >= (1, 6):
+    TEST_RUNNER = 'django.test.simple.DjangoTestSuiteRunner'
+
 SKIP_SOUTH_TESTS = True
 
 # Settings for puppet views
@@ -207,9 +213,6 @@ SOUTH_MIGRATION_MODULES = {
 # Silence the erroneous 1_6.W001 check. It was removed in
 # https://code.djangoproject.com/ticket/23469 anyway
 SILENCED_SYSTEM_CHECKS = ['1_6.W001']
-
-# Use the old pre 1.6 testrunner
-TEST_RUNNER = 'django.test.simple.DjangoTestSuiteRunner'
 
 # Django extensions (apt-get install python-django-extensions)
 try:


### PR DESCRIPTION
Changing the entire WSGI setup is warranted. Stop the practice of having
the user configure the path in the WSGI application module, and move it
along the rest of the project since it now is a shipped module. This
should allow easier setting up of the project in application servers.
Update the example gunicorn configuration to work with the WSGI way
since this is the prefered method since Django 1.5
