### PR TITLE
Getting ready for a 0.7 release

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,6 @@
 Copyright © 2010-2013 Greek Research and Technology Network (GRNET S.A.)
 Copyright © 2012 Faidon Liambotis
-Copyright © 2013 Alexandros Kosiaris
+Copyright © 2013-2015 Alexandros Kosiaris
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -43,7 +43,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"servermon"
-copyright = u"2013, GRNET S.A. 2013 Alexandros Kosiaris"
+copyright = u"2013, GRNET S.A. 2013-2015, Alexandros Kosiaris"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pbr<0.11
-Django>=1.3,<1.5
+Django>=1.3,<1.7
 south
 whoosh
 ipy


### PR DESCRIPTION
Add support for Django 1.5 and Django 1.6 as tests pass for them and the
supplied gunicorn as well as the wsgi configuration works fine. In 1.7
these things no longer work and need to be updated. That and the
migrations changes in 1.7 warrant a non support status for servermon 0.7
Update global copyrights as well