### PR TITLE
Reorganize location information generation

### DIFF
--- a/servermon/hwdoc/models.py
+++ b/servermon/hwdoc/models.py
@@ -138,6 +138,10 @@ class Datacenter(models.Model):
     def __unicode__(self):
         return self.name
 
+    @models.permalink
+    def get_absolute_url(self):
+        return ('hwdoc.views.datacenter', [str(self.id)])
+
 
 class Vendor(models.Model):
     '''
@@ -228,6 +232,10 @@ class Rack(models.Model):
             units.extend(z)
         empty_units = set(self.model.units) - set(sorted(units))
         return empty_units
+
+    @models.permalink
+    def get_absolute_url(self):
+        return ('hwdoc.views.rack', [str(self.id)])
 
 
 class RackRow(models.Model):

--- a/servermon/updates/templates/hostview.html
+++ b/servermon/updates/templates/hostview.html
@@ -35,11 +35,13 @@
       {% if attr.value %}
       <tr>
         <th>{{ attr.name }}</th>
-        {% ifequal attr.name "IPMI Hostname" %}
-        <td><a href="https://{{ attr.value }}">{{ attr.value }}</a></td>
-        {% else %}
-        <td>{{ attr.value }}</td>
-        {% endifequal %}
+	<td>
+	{% if attr.link %}
+        <a href="{{ attr.link }}">{{ attr.value }}</a>
+	{% else %}
+        {{ attr.value }}
+	{% endif %}
+	</td>
       </tr>
       {% endif %}
       {% endfor %}

--- a/servermon/updates/tests.py
+++ b/servermon/updates/tests.py
@@ -104,6 +104,7 @@ class ViewsTestCase(unittest.TestCase):
         self.package2 = Package.objects.create(name='testpackage2', sourcename='testsource')
         self.host1 = Host.objects.create(name='testservermonHost1', ip='10.10.10.10')
         self.host2 = Host.objects.create(name='testservermonHost2', ip='10.10.10.11')
+        self.host3 = Host.objects.create(name='testservermonHost3', ip='10.10.10.12')
         self.fact1 = Fact.objects.create(name='interfaces')
         self.fact2 = Fact.objects.create(name='macaddress_eth0')
         self.fact3 = Fact.objects.create(name='ipaddress_eth0')
@@ -128,6 +129,9 @@ class ViewsTestCase(unittest.TestCase):
         self.factvalue6 = FactValue.objects.create(
             value='R123457',
             fact_name=self.fact6, host=self.host2)
+        self.factvalue7 = FactValue.objects.create(
+            value='G123456',
+            fact_name=self.fact6, host=self.host3)
 
     def tearDown(self):
         '''
@@ -192,7 +196,7 @@ class ViewsTestCase(unittest.TestCase):
 
     def test_existent_host(self):
         c = Client()
-        data = [self.host1.name]
+        data = [self.host1.name, self.host2.name, self.host3.name]
         for d in data:
             response = c.get('/hosts/%s' % d)
             self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Location generation information in the puppet hostview is suboptimal and
has some hardcoded values. It fails for any host not having any other
specified attributes resulting in a no location information line
displayed. Reorganize it in a anonymous function way, avoiding that
problem and move the link approach into an attribute