### PR TITLE
make_updates: Run everything in a transaction

### DIFF
--- a/servermon/updates/management/commands/make_updates.py
+++ b/servermon/updates/management/commands/make_updates.py
@@ -35,6 +35,7 @@ class Command(BaseCommand):
     '''
     help = _l('Populate updatable packages in DB')
 
+    @transaction.commit_on_success
     def handle(self, *args, **options):
         '''
         Handle command
@@ -44,7 +45,6 @@ class Command(BaseCommand):
 
         Package.objects.filter(hosts__isnull=True).delete()
 
-    @transaction.commit_on_success
     def gen_host_updates(self, host):
         '''
         Populate all updates


### PR DESCRIPTION
Run the entire make_updates command in a transaction avoiding race
conditions with servers updating their package_updates fact in between
run and causing issues like servers needing updates not displaying them.
This way a more consistent image of the state of the puppet agent boxes
is displayed