### PR TITLE
Add demo documentation in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,3 +64,8 @@ Documentation
 
 The documentation is maintained using Sphinx (under /doc/) and is automatically
 generated at https://servermon.readthedocs.org/.
+
+Demo
+====
+
+Demo at http://servermon.herokuapp.com


### PR DESCRIPTION
We have a demo running in heroku these days, add a link to it in the
README