### PR TITLE
Add exclusion to 'processors' fact from 'Processor type'

### DIFF
--- a/servermon/updates/views.py
+++ b/servermon/updates/views.py
@@ -169,7 +169,7 @@ def host(request, hostname):
 
     system.append({
         'name': 'Processor type',
-        'value': ', '.join([p['value'] for p in host.factvalue_set.filter(fact_name__name__startswith='processor').exclude(fact_name__name='processorcount').values('value').distinct()]),
+        'value': ', '.join([p['value'] for p in host.factvalue_set.filter(fact_name__name__startswith='processor').exclude(fact_name__name='processorcount').exclude(fact_name__name='processors').values('value').distinct()]),
     })
 
     system.append({


### PR DESCRIPTION
facter 2.2 includes a new fact called 'processors' which is in the form
of:
processors => {"models"=>["QEMU Virtual CPU version 2.1.2"], "count"=>1, "physicalcount"=>1}

This patch clears the output of 'Processor type' from this fact.