### PR TITLE
Fix E402 flake8/pep8 warnings

### DIFF
--- a/servermon/apt2xml.py
+++ b/servermon/apt2xml.py
@@ -22,10 +22,10 @@ CLI utility to get package update and print them in XML format
 
 
 from socket import getfqdn
+from xml.dom.minidom import Document
+import apt
 import warnings
 warnings.filterwarnings('ignore')
-import apt
-from xml.dom.minidom import Document
 
 
 # shamelessly stolen from /usr/lib/update-notifier/apt_check.py ported/modified

--- a/servermon/urls.py
+++ b/servermon/urls.py
@@ -1,10 +1,10 @@
+from django.conf import settings
 from django import VERSION as DJANGO_VERSION
 if DJANGO_VERSION[:2] >= (1, 4):
     from django.conf.urls import patterns, include, url
 else:
     from django.conf.urls.defaults import patterns, include, url
 
-from django.conf import settings
 
 urlpatterns = patterns('',
     (r'^/?$', 'projectwide.views.index'),  # noqa


### PR DESCRIPTION
pep8 >= 1.6 (wrapped by flake8) checks for E402 which is:

E402 module level import not at top of file

causing errors in 2 files. Since the fixes are trivial, apply them by
shifting around the import order