### PR TITLE
Remove pbr from test requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pbr<0.11
 Django>=1.3,<1.7
 south
 whoosh

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
-pbr<0.11
 south
 whoosh
 ipy


### PR DESCRIPTION
As the test suite does not actually use pbr, and its inclusion pinned
with version 0.11 causes problems with pip > 8 during testing, remove
it. It was probably wrongly added in the first place