### PR TITLE
Force virtualenv version in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - "2.7"
-install: pip install tox
+install: pip install 'virtualenv==13.1.2' 'tox'
 script: tox
 sudo: false
 env:


### PR DESCRIPTION
To bypass a number of issues with recent builds in travis, force the
virtualenv version to 13.1.2 as it is the last stable virtualenv version
we had no problems with. This is a temporary measure to get Travis
builds working fine again and needs to be investigated better and fixed.
The solution however seems to be dependent on migrating to SemVer and
pbr > 0.11 which is going to take a while to happen