### PR TITLE
Ignore coverage outcome in tox return

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ whitelist_externals = cp
 commands = flake8
 
 [testenv:coverage]
+ignore_outcome = True
 commands = python -m coverage combine
            python -m coverage html
            coveralls


### PR DESCRIPTION
It might happen that coveralls returns an error, which is coveralls API
dependent and does not happen always. Set the coverage testenv to ignore
to avoid the entire build triggering a fail