### PR TITLE
Add a working wsgi file

### DIFF
--- a/servermon/wsgi.py
+++ b/servermon/wsgi.py
@@ -17,9 +17,13 @@
 
 import os
 import sys
-sys.path.append('/path/to/app/')
-os.environ['DJANGO_SETTINGS_MODULE'] = 'servermon.settings'
+parent_path = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.pardir))
+sys.path.append(parent_path)
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'servermon.settings')
 
-import django.core.handlers.wsgi
-
-application = django.core.handlers.wsgi.WSGIHandler()
+try:
+    from django.core.wsgi import get_wsgi_application
+    application = get_wsgi_application()
+except ImportError:
+    import django.core.handlers.wsgi
+    application = django.core.handlers.wsgi.WSGIHandler()


### PR DESCRIPTION
Up to now, our wsgi file was not working out of the box, but rather
required the administrator/operator to modify it specifying the path.
Then gunicorn or apache mod_wsgi was the recommended way of running the
service. Gunicorn was recommended to be setup in the "django" mode, from
which the need for the modifiable wsgi was born. However, starting with
Django 1.7 the WSGI mode is now mandatory and the old approach no longer
works. Since this approach seems to work with version 1.3 and above,
ship a working WSGI file. Further things are needed down the path, live
path moves to adhere to better path handling introduced in Django 1.4
and above but these are to come to later patches