### PR TITLE
keyvalue: Print the object associated as well

### DIFF
--- a/servermon/keyvalue/models.py
+++ b/servermon/keyvalue/models.py
@@ -82,5 +82,8 @@ class KeyValue(models.Model):
         return self.owner_content_object
 
     def __unicode__(self):
-        res = u'%s = %s' % (self.key.name, self.value)
+        res = u'%s = %s on %s' % (
+            self.key.name,
+            self.value,
+            self.owner_content_object)
         return res

--- a/servermon/keyvalue/tests.py
+++ b/servermon/keyvalue/tests.py
@@ -64,7 +64,7 @@ class KeyTestCase(unittest.TestCase):
         self.assertEqual(self.keyvalue.value, 'Yo')
         self.assertEqual(self.keyvalue.owner, self.owner)
         # Test __unicode__ method on KeyValue
-        self.assertEqual(str(self.keyvalue), 'Key1 = Yo')
+        self.assertEqual(str(self.keyvalue), 'Key1 = Yo on Owner')
 
 
 class AdminViewsTestCase(unittest.TestCase):


### PR DESCRIPTION
The __unicode__ function would not show the associated object when used.
Add that functionality