### PR TITLE
Remove django syncdb/migrate from tox commmands

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,9 +20,6 @@ deps = -r{toxinidir}/test-requirements.txt
        django17: Django>=1.7,<1.8
        django18: Django>=1.8,<1.9
 commands = cp servermon/settings.py.dist servermon/settings.py
-           rm -f servermon-test.db
-           python servermon/manage.py syncdb --noinput --settings=settings_test_{env:DB:sqlite}
-           python servermon/manage.py migrate --noinput --settings=settings_test_{env:DB:sqlite}
            python -m coverage run servermon/manage.py test --noinput --settings=settings_test_{env:DB:sqlite}
 whitelist_externals = cp
                       rm


### PR DESCRIPTION
Issuing syncdb/migrate commands in every tox environment before testing
is not necessary since django tests use their test own database for
these things. Also, it's not idempotent, making it possible that the
syncdb and migration stage break. Remove them