### PR TITLE
Use datetime in hwdoc migration 0031

### DIFF
--- a/servermon/hwdoc/south_migrations/0031_auto__add_field_project_comments.py
+++ b/servermon/hwdoc/south_migrations/0031_auto__add_field_project_comments.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from south.utils import datetime_utils as datetime
+import datetime
 from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models


### PR DESCRIPTION
South migration 0031 is not compatible with south 0.7.3 since that
version of south does not have the south.utils package. Alter the
migration to use the standard datetime import that all other migrations
in the project use

This closes #184