### PR TITLE
Test various south versions in tox

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
-south
 whoosh
 ipy
 python-ldap

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = doc,flake8,django{13,14,15,16,17},coverage
+envlist = doc,flake8,django13-south{075,100},django{14,15,16}-south{075,100},django17,coverage
 
 ;
 ; test environnements
@@ -19,6 +19,10 @@ deps = -r{toxinidir}/test-requirements.txt
        django16: Django>=1.6,<1.7
        django17: Django>=1.7,<1.8
        django18: Django>=1.8,<1.9
+; 0.7.3 has a failing mysql test in hwdoc migration 0007 and only support Django 1.3. Skip it for now
+       south073: south==0.7.3
+       south075: south==0.7.5
+       south100: south>=1.0
 commands = cp servermon/settings.py.dist servermon/settings.py
            python -m coverage run servermon/manage.py test --noinput --settings=settings_test_{env:DB:sqlite}
 whitelist_externals = cp


### PR DESCRIPTION
Since we recently got bitten by south version incompatibilities (#184),
let's test the various south versions we support