### PR TITLE
Add .venv directory in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /dist/
 /servermon/settings.py
 .*.swp
+.venv
 /docbuild
 *.sqlite*
 *.db


### PR DESCRIPTION
Ignore virtualenvs under the .venv directory, to allow easier usage of
virtualenvs