### PR TITLE
Pin flake8 version to 3.0.4

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ south
 whoosh
 ipy
 python-ldap
-flake8
+flake8==3.0.4
 epydoc
 sphinx
 pysqlite


### PR DESCRIPTION
Pin flake8 version so that we don't get PRs that fail for newly enforced
style guidelines that aren't yet known/vetted by the project. This
should allow for a more stable style that changes on demand and not
automatically