### PR TITLE
Add Django 1.8 and Django 1.9 in the tox tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = doc,flake8,django{13,14,15,16,17},coverage
+envlist = doc,flake8,django{13,14,15,16,17,18,19},coverage
 
 ;
 ; test environnements
@@ -19,6 +19,7 @@ deps = -r{toxinidir}/test-requirements.txt
        django16: Django>=1.6,<1.7
        django17: Django>=1.7,<1.8
        django18: Django>=1.8,<1.9
+       django19: Django>=1.9,<1.10
 commands = cp servermon/settings.py.dist servermon/settings.py
            python -m coverage run servermon/manage.py test --noinput --settings=settings_test_{env:DB:sqlite}
 whitelist_externals = cp


### PR DESCRIPTION
Enable testing Django 1.8 and Django 1.9 in our tox environments. This
should allow adding support for these 2 versions of django in the future