### PR TITLE
Fix host URLs in Puppet Inventory query results page

### DIFF
--- a/servermon/puppet/templates/query_results.html
+++ b/servermon/puppet/templates/query_results.html
@@ -20,7 +20,7 @@
       <tbody>
         {% for res in results %}
         <tr>
-          <td><a href="{% url "updates.views.host" res.host.name %}">{{ res.host }}</a></td>
+          <td><a href="{% url "updates.views.host" res.host %}">{{ res.host }}</a></td>
           {% for fact in res.facts %}
           <td>{% if fact %}{{ fact }}{% else %}&mdash;{% endif %}</td>
           {% endfor %}


### PR DESCRIPTION
A wrong argument was passed to the url template function in
query_results.html template causing URLs to hosts in that view to be
incorrect, all pointing to /hosts instead of /hosts/<hostname>. Fix that
y using the correct argument