### PR TITLE
Linkify rack and dc in equipment and search views

### DIFF
--- a/servermon/hwdoc/templates/equipment.html
+++ b/servermon/hwdoc/templates/equipment.html
@@ -18,7 +18,8 @@
         <tr><th>{% trans "Project" %}:</th><td>{% if equipment.allocation %}<a href="{% url "hwdoc.views.project" equipment.allocation.pk %}">{{ equipment.allocation.name }}</a>{% else %}-{% endif %}</td></tr>
         <tr><th>{% trans "Model" %}:</th><td>{{ equipment.model }}</td></tr>
         <tr><th>{% trans "Serial" %}:</th><td>{{ equipment.serial }}</td></tr>
-        <tr><th>{% trans "Rack Unit" %}:</th><td>{% if equipment.rack %}{{ equipment.rack }}{% if equipment.unit %}{{ equipment.unit|stringformat:"02d" }}{% endif %}{% else %}-{% endif %}</td></tr>
+        <tr><th>{% trans "Rack" %}:</th><td>{% if equipment.rack %}<a href="{% url "hwdoc.views.rack" equipment.rack.pk %}">{{ equipment.rack }}</a>{% else %}-{% endif %}</td></tr>
+        <tr><th>{% trans "RackUnit" %}:</th><td>{% if equipment.rack %}{{ equipment.rack }}</a>{% if equipment.unit %}{{ equipment.unit|stringformat:"02d" }}{% endif %}{% else %}-{% endif %}</td></tr>
         <tr><th>{% trans "Purpose" %}:</th><td>{{ equipment.purpose }}</td></tr>
         <tr><th>{% trans "OOB MAC" %}:</th><td>{% if equipment.servermanagement %}{{ equipment.servermanagement.mac }}{% endif %}</td></tr>
         <tr><th>{% trans "OOB Hostname" %}:</th><td>{% if equipment.servermanagement %}<a href="https://{{ equipment.servermanagement.hostname }}">{{ equipment.servermanagement.hostname }}</a>{% endif %}</td></tr>

--- a/servermon/projectwide/templates/hwdoc_searchresults.html
+++ b/servermon/projectwide/templates/hwdoc_searchresults.html
@@ -68,8 +68,8 @@
           {% endif %}
           {% endif %}
           <td>{{ result.model.vendor }}&nbsp;{{ result.model.name }}</td>
-          <td>{{ result.dc }}</td>
-          <td>{{ result.rack }}</td>
+          <td>{% if result.dc %}<a href="{% url "hwdoc.views.datacenter" result.dc.pk %}">{{ result.dc }}</a>{% endif %}</td>
+          <td>{% if result.rack %}<a href="{% url "hwdoc.views.rack" result.rack.pk %}">{{ result.rack }}</a>{% endif %}</td>
 	  <td>{% for unit in result.model.units %}{{ result.unit|add:unit|add:"-1"|stringformat:"02d" }}<br/>{% endfor %}</td>
           <td class="centered">{% if result.rack_front %}<i class="icon-ok-sign"></i>{% else %}&nbsp;{% endif %}</td>
           <td class="centered">{% if result.rack_interior %}<i class="icon-ok-sign"></i>{% else %}&nbsp;{% endif %}</td>


### PR DESCRIPTION
Per #195, it would be useful from a UX perspective, to have links
directly to rack from the equipment and the search results views. Adding
that as well as a link to the DC in the search results view. To make the
result look better and still not break backwards compatibility with the
display or the rackunit, add a new row containing just the rack

This closes #195