### PR TITLE
Ignore exuberant ctags files in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 AUTHORS
 ChangeLog
 .coverage
+/tags


### PR DESCRIPTION
Add /tags in .gitignore