### PR TITLE
Fix a few unspecified Exceptions

### DIFF
--- a/servermon/djangobackends/ldapBackend.py
+++ b/servermon/djangobackends/ldapBackend.py
@@ -84,7 +84,7 @@ class ldapBackend(object):
                     try:
                         g = Group.objects.get(name=settings.LDAP_AUTH_GROUP)
                         user.groups.add(g)
-                    except:
+                    except Group.DoesNotExist:
                         pass
             # Whatever the result of the two above, sync up non autorization
             # data from LDAP to django

--- a/servermon/puppet/models.py
+++ b/servermon/puppet/models.py
@@ -100,7 +100,7 @@ class Host(models.Model):
 
         try:
             return self.factvalue_set.get(fact_name__name=fact).value
-        except:
+        except FactValue.DoesNotExist:
             return default
 
 


### PR DESCRIPTION
It's error prone to unconditionally catch all Exception types, so catch
only the Exceptions that can actually be emitted