### PR TITLE
Remove pbr version lock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - "2.7"
-install: pip install 'virtualenv==13.1.2' 'tox'
+install: pip install tox
 script: tox
 sudo: false
 env:

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,4 +1,4 @@
-pbr<0.11
+pbr
 Django>=1.3,<1.5
 south
 whoosh

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 name = servermon
+version = 0.6.1
 author = Alexandros Kosiaris
 author_email = akosiaris@gmail.com
 summary = An inventory project to facilitate server monitoring and management through Puppet.

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@
 from setuptools import setup
 
 setup(
-    setup_requires=['pbr<0.11'],
+    setup_requires=['pbr'],
     pbr=True,
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ ipy
 python-ldap
 flake8==3.0.4
 epydoc
-sphinx
+sphinx==1.6.3
 pysqlite
 mock<1.1.0
 mockldap

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ commands = python -m coverage combine
 [testenv:doc]
 commands = mkdir -p docbuild/api
            epydoc --config doc/epydoc.conf -o docbuild/api
+           python setup.py build
            python setup.py build_sphinx --builder html
            python setup.py build_sphinx --builder text
 whitelist_externals = mkdir


### PR DESCRIPTION
We lock pbr to versions lower than 0.11 as that is the version that
started forcing SemVer. Back then it was expected we would have had
migrated to it soon, it still hasn't happened. Let's see if we can undo
the version lock