### PR TITLE
Don't hardcode STATIC_URL in urls

### DIFF
--- a/servermon/servermon/urls.py
+++ b/servermon/servermon/urls.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.conf.urls import patterns, include, url
+import os
 
 urlpatterns = patterns('',
     (r'^/?$', 'projectwide.views.index'),  # noqa
@@ -28,7 +29,9 @@ if 'django.contrib.admin' in settings.INSTALLED_APPS:
         (r'^admin/doc/', include('django.contrib.admindocs.urls')),
     )
 
-if settings.DEBUG:
+# If we are debugging or we are running in a heroku environment, we want static
+# file serving by gunicorn
+if settings.DEBUG or 'DATABASE_URL' in os.environ:
     urlpatterns += patterns('',
-        (r'^static/(?P<path>.*)$', 'django.contrib.staticfiles.views.serve') # noqa
+        (r'^%s/(?P<path>.*)$' % settings.STATIC_URL.lstrip('/'), 'django.contrib.staticfiles.views.serve') # noqa
     )


### PR DESCRIPTION
Instead of using "static", use the value from settings.STATIC_URL. Also
detect if we are running in a heroku environment by the use of the
DATABASE_URL environment variable and serve static files in there as well