### PR TITLE
Migrate to mysqlclient from MySQL-python

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,5 +9,5 @@ mock<1.1.0
 mockldap
 coverage
 coveralls
-MySQL-python
+mysqlclient
 psycopg2==2.4.1


### PR DESCRIPTION
The MySQL-python package does not provide support for python 3.x and has
been forked into the mysqlclient package that does and continues
development