### PR TITLE
Replace an erroneous filter() with a get()

### DIFF
--- a/servermon/updates/management/commands/make_updates.py
+++ b/servermon/updates/management/commands/make_updates.py
@@ -68,10 +68,8 @@ class Command(BaseCommand):
             is_sec = (update.getAttribute("is_security") == "true")
 
             try:
-                p = Package.objects.filter(name=name)[0]
-            except IndexError:
-                p = None
-            if not p:
+                p = Package.objects.get(name=name)
+            except Package.DoesNotExist:
                 p = Package(name=name, sourcename=sn)
                 p.save()
 


### PR DESCRIPTION
Using a filter()[0] and relying on catching IndexError is not the django
way. Instead rely on a get and catch the DoesNotExist exception