### PR TITLE
Remove a stray tab character

### DIFF
--- a/servermon/hwdoc/south_migrations/0005_migrate_states.py
+++ b/servermon/hwdoc/south_migrations/0005_migrate_states.py
@@ -9,7 +9,7 @@ class Migration(DataMigration):
 
     def forwards(self, orm):
         equipments = orm['hwdoc.Equipment'].objects.all()
-    	try:
+        try:
             # WORKING - OK => Functional
             equipments.filter(state='0').update(temp=orm['hwdoc.State'].objects.get(name='Functional'))
             # WORKING - RMA => Component RMA


### PR DESCRIPTION
Python best practive says only spaces, so replace it with the standard 4
spaces.