### PR TITLE
Fully qualify settings_test import from DB variants

### DIFF
--- a/servermon/servermon/settings_test.py
+++ b/servermon/servermon/settings_test.py
@@ -1,4 +1,4 @@
-from settings import *  # noqa
+from servermon.settings import *  # noqa
 
 DATABASES['default']['ENGINE'] = 'django.db.backends.sqlite3'  # noqa
 DATABASES['default']['NAME'] = 'servermon-test.db'  # noqa

--- a/servermon/servermon/settings_test_mysql.py
+++ b/servermon/servermon/settings_test_mysql.py
@@ -1,4 +1,4 @@
-from settings_test import *  # noqa
+from servermon.settings_test import *  # noqa
 
 DATABASES['default']['ENGINE'] = 'django.db.backends.mysql'  # noqa
 DATABASES['default']['NAME'] = 'servermon'  # noqa

--- a/servermon/servermon/settings_test_postgres.py
+++ b/servermon/servermon/settings_test_postgres.py
@@ -1,4 +1,4 @@
-from settings_test import *  # noqa
+from servermon.settings_test import *  # noqa
 
 DATABASES['default']['ENGINE'] = 'django.db.backends.postgresql_psycopg2'  # noqa
 DATABASES['default']['NAME'] = 'servermon'  # noqa

--- a/servermon/servermon/settings_test_sqlite.py
+++ b/servermon/servermon/settings_test_sqlite.py
@@ -1,4 +1,4 @@
-from settings_test import *  # noqa
+from servermon.settings_test import *  # noqa
 
 DATABASES['default']['ENGINE'] = 'django.db.backends.sqlite3'  # noqa
 DATABASES['default']['NAME'] = 'servermon-test.db'  # noqa


### PR DESCRIPTION
Try to avoid the relative import and fully qualify the settings_test
and settings module import to avoid python3 crawking on it