### PR TITLE
Use an explicit relative import for _bmc_common

### DIFF
--- a/servermon/hwdoc/management/commands/hwdoc_add_user.py
+++ b/servermon/hwdoc/management/commands/hwdoc_add_user.py
@@ -24,7 +24,7 @@ from django.utils.translation import ugettext_lazy as _l
 
 from optparse import make_option
 
-import _bmc_common
+from . import _bmc_common
 
 
 class Command(BaseCommand):

--- a/servermon/hwdoc/management/commands/hwdoc_bmc_factory_defaults.py
+++ b/servermon/hwdoc/management/commands/hwdoc_bmc_factory_defaults.py
@@ -21,7 +21,7 @@ Django management command to reset BMC factory defaults
 from django.core.management.base import BaseCommand
 from django.utils.translation import ugettext_lazy as _l
 
-import _bmc_common
+from . import _bmc_common
 
 
 class Command(BaseCommand):

--- a/servermon/hwdoc/management/commands/hwdoc_bmc_reset.py
+++ b/servermon/hwdoc/management/commands/hwdoc_bmc_reset.py
@@ -21,7 +21,7 @@ Django management command to reset a BMC
 from django.core.management.base import BaseCommand
 from django.utils.translation import ugettext_lazy as _l
 
-import _bmc_common
+from . import _bmc_common
 
 
 class Command(BaseCommand):

--- a/servermon/hwdoc/management/commands/hwdoc_boot_order.py
+++ b/servermon/hwdoc/management/commands/hwdoc_boot_order.py
@@ -23,7 +23,7 @@ from django.utils.translation import ugettext_lazy as _l
 
 from optparse import make_option
 
-import _bmc_common
+from . import _bmc_common
 
 
 class Command(BaseCommand):

--- a/servermon/hwdoc/management/commands/hwdoc_firmware_update.py
+++ b/servermon/hwdoc/management/commands/hwdoc_firmware_update.py
@@ -25,7 +25,7 @@ from django.utils.translation import ugettext_lazy as _l
 from os.path import isfile
 from optparse import make_option
 
-import _bmc_common
+from . import _bmc_common
 
 
 class Command(BaseCommand):

--- a/servermon/hwdoc/management/commands/hwdoc_get_all_users.py
+++ b/servermon/hwdoc/management/commands/hwdoc_get_all_users.py
@@ -21,7 +21,7 @@ Django management command to add user to BMC
 from django.core.management.base import BaseCommand
 from django.utils.translation import ugettext_lazy as _l
 
-import _bmc_common
+from . import _bmc_common
 
 
 class Command(BaseCommand):

--- a/servermon/hwdoc/management/commands/hwdoc_license.py
+++ b/servermon/hwdoc/management/commands/hwdoc_license.py
@@ -23,7 +23,7 @@ from django.utils.translation import ugettext_lazy as _l
 
 from optparse import make_option
 
-import _bmc_common
+from . import _bmc_common
 
 
 class Command(BaseCommand):

--- a/servermon/hwdoc/management/commands/hwdoc_pass_change.py
+++ b/servermon/hwdoc/management/commands/hwdoc_pass_change.py
@@ -24,7 +24,7 @@ from django.utils.translation import ugettext_lazy as _l
 
 from optparse import make_option
 
-import _bmc_common
+from . import _bmc_common
 
 
 class Command(BaseCommand):

--- a/servermon/hwdoc/management/commands/hwdoc_power_cycle.py
+++ b/servermon/hwdoc/management/commands/hwdoc_power_cycle.py
@@ -21,7 +21,7 @@ Django management command to cold boot equipment
 from django.core.management.base import BaseCommand
 from django.utils.translation import ugettext_lazy as _l
 
-import _bmc_common
+from . import _bmc_common
 
 
 class Command(BaseCommand):

--- a/servermon/hwdoc/management/commands/hwdoc_remove_user.py
+++ b/servermon/hwdoc/management/commands/hwdoc_remove_user.py
@@ -24,7 +24,7 @@ from django.utils.translation import ugettext_lazy as _l
 
 from optparse import make_option
 
-import _bmc_common
+from . import _bmc_common
 
 
 class Command(BaseCommand):

--- a/servermon/hwdoc/management/commands/hwdoc_reset.py
+++ b/servermon/hwdoc/management/commands/hwdoc_reset.py
@@ -21,7 +21,7 @@ Django management command to warm boot equipment
 from django.core.management.base import BaseCommand
 from django.utils.translation import ugettext_lazy as _l
 
-import _bmc_common
+from . import _bmc_common
 
 
 class Command(BaseCommand):

--- a/servermon/hwdoc/management/commands/hwdoc_set_ldap_settings.py
+++ b/servermon/hwdoc/management/commands/hwdoc_set_ldap_settings.py
@@ -23,7 +23,7 @@ from django.utils.translation import ugettext_lazy as _l
 
 from optparse import make_option
 
-import _bmc_common
+from . import _bmc_common
 
 
 class Command(BaseCommand):

--- a/servermon/hwdoc/management/commands/hwdoc_set_settings.py
+++ b/servermon/hwdoc/management/commands/hwdoc_set_settings.py
@@ -23,7 +23,7 @@ from django.utils.translation import ugettext_lazy as _l
 
 from optparse import make_option
 
-import _bmc_common
+from . import _bmc_common
 
 
 class Command(BaseCommand):

--- a/servermon/hwdoc/management/commands/hwdoc_shutdown.py
+++ b/servermon/hwdoc/management/commands/hwdoc_shutdown.py
@@ -24,7 +24,7 @@ from django.utils.translation import ugettext_lazy as _l
 
 from optparse import make_option
 
-import _bmc_common
+from . import _bmc_common
 
 
 class Command(BaseCommand):

--- a/servermon/hwdoc/management/commands/hwdoc_startup.py
+++ b/servermon/hwdoc/management/commands/hwdoc_startup.py
@@ -21,7 +21,7 @@ Django management command to start equipment
 from django.core.management.base import BaseCommand
 from django.utils.translation import ugettext as _
 
-import _bmc_common
+from . import _bmc_common
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
_bmc_common private module abstracts away some of the common code shared
by all hwdoc management commands. While a relative implicit import is
fine in python 2.x, in python 3.x it is not allowed. Migrate to an
explicit relative import. Using an absolute import here would break the
idea behind this and would expose the django management commands
hierarchy to the module which is not really useful or wanted