### PR TITLE
Use text mode for opened csv files

### DIFF
--- a/servermon/hwdoc/management/commands/hwdoc_importequipment.py
+++ b/servermon/hwdoc/management/commands/hwdoc_importequipment.py
@@ -24,6 +24,7 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy as _l
 import csv
 import re
+import io
 
 
 class Command(BaseCommand):
@@ -45,7 +46,7 @@ class Command(BaseCommand):
 
         count = 0
         try:
-            with open(csvname, 'rb') as f:
+            with io.open(csvname, 'r') as f:
                 reader = csv.reader(f)
                 for row in reader:
                     (aa, eq, sn, dns, passwd, rack, unit, pdua, pdub, mac) = row[:10]

--- a/servermon/hwdoc/management/commands/hwdoc_importequipmentlicenses.py
+++ b/servermon/hwdoc/management/commands/hwdoc_importequipmentlicenses.py
@@ -22,6 +22,7 @@ from django.core.management.base import BaseCommand, CommandError
 from hwdoc.models import Equipment
 from django.utils.translation import ugettext as _
 import csv
+import io
 
 
 class Command(BaseCommand):
@@ -42,7 +43,7 @@ class Command(BaseCommand):
         csvname = args[0]
         licenses = []
 
-        with open(csvname, 'rb') as f:
+        with io.open(csvname, 'r') as f:
             reader = csv.reader(f)
             for row in reader:
                 (foo, license, serial) = row


### PR DESCRIPTION
For some reason the equipment importing django management commands were
using binary mode instead of text mode. Switch to text mode instead as
the binary mode is not python3 compatible and is anyway wrong for
python2 + unicode characters (which we hope to never see in this
context)