### PR TITLE
Use python_2_unicode_compatible in all models

### DIFF
--- a/servermon/hwdoc/models.py
+++ b/servermon/hwdoc/models.py
@@ -19,12 +19,14 @@ hwdoc module's functions documentation. Main models are Equipment and ServerMana
 '''
 
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext as _
 from django.contrib.contenttypes import generic
 from keyvalue.models import KeyValue
 
 
 # Allocation models #
+@python_2_unicode_compatible
 class Email(models.Model):
     '''
     Email Model. Represents an email. No special checks are done for user input
@@ -36,10 +38,11 @@ class Email(models.Model):
         verbose_name = _(u'Email')
         verbose_name_plural = _(u'Emails')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.email
 
 
+@python_2_unicode_compatible
 class Phone(models.Model):
     '''
     Phone Model. Represents a phone. No special checks are done for user input
@@ -51,10 +54,11 @@ class Phone(models.Model):
         verbose_name = _(u'Phone')
         verbose_name_plural = _(u'Phones')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.number
 
 
+@python_2_unicode_compatible
 class Person(models.Model):
     '''
     Person Model. Represents a Person with relations to Email, Phone
@@ -70,7 +74,7 @@ class Person(models.Model):
         verbose_name = _(u'Person')
         verbose_name_plural = _(u'People')
 
-    def __unicode__(self):
+    def __str__(self):
         result = u'%s %s ' % (self.name, self.surname)
         if self.emails.count() > 0:
             result += u'<%s> ' % ', '.join(map(lambda x: x[0], self.emails.values_list('email')))
@@ -79,6 +83,7 @@ class Person(models.Model):
         return result
 
 
+@python_2_unicode_compatible
 class Project(models.Model):
     '''
     Project Model. The idea is to allocate Equipments to Projects
@@ -93,10 +98,11 @@ class Project(models.Model):
         verbose_name = _(u'Project')
         verbose_name_plural = _(u'Projects')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
+@python_2_unicode_compatible
 class Role(models.Model):
     '''
     Roles for projects
@@ -114,7 +120,7 @@ class Role(models.Model):
         verbose_name = _(u'Role')
         verbose_name_plural = _(u'Roles')
 
-    def __unicode__(self):
+    def __str__(self):
         return _(u'Project: %(project)s, Person: %(name)s %(surname)s, Role: %(role)s') % {
             'project': self.project.name,
             'name': self.person.name,
@@ -124,6 +130,7 @@ class Role(models.Model):
 
 
 # Equipment models #
+@python_2_unicode_compatible
 class Datacenter(models.Model):
     '''
     Datacenters
@@ -136,7 +143,7 @@ class Datacenter(models.Model):
         verbose_name = _(u'Datacenter')
         verbose_name_plural = _(u'Datacenters')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     @models.permalink
@@ -144,6 +151,7 @@ class Datacenter(models.Model):
         return ('hwdoc.views.datacenter', [str(self.id)])
 
 
+@python_2_unicode_compatible
 class Vendor(models.Model):
     '''
     Equipments have Models and belong to Vendors
@@ -156,7 +164,7 @@ class Vendor(models.Model):
         verbose_name = _(u'Vendor')
         verbose_name_plural = _(u'Vendors')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
@@ -174,6 +182,7 @@ class Model(models.Model):
         verbose_name_plural = _(u'Models')
 
 
+@python_2_unicode_compatible
 class RackModel(Model):
     '''
     Rack vendor models
@@ -189,7 +198,7 @@ class RackModel(Model):
         verbose_name = _(u'Rack Model')
         verbose_name_plural = _(u'Rack Models')
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s %s' % (self.vendor, self.name)
 
     @property
@@ -197,6 +206,7 @@ class RackModel(Model):
         return reversed(range(1, self.height + 1))
 
 
+@python_2_unicode_compatible
 class Rack(models.Model):
     '''
     Racks
@@ -211,7 +221,7 @@ class Rack(models.Model):
         verbose_name = _(u'Rack')
         verbose_name_plural = _(u'Racks')
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s' % (self.name)
 
     def get_empty_units(self, related=None):
@@ -239,6 +249,7 @@ class Rack(models.Model):
         return ('hwdoc.views.rack', [str(self.id)])
 
 
+@python_2_unicode_compatible
 class RackRow(models.Model):
     '''
     Racks in a row are a RackRow
@@ -252,10 +263,11 @@ class RackRow(models.Model):
         verbose_name = _(u'Rack Row')
         verbose_name_plural = _(u'Rack Rows')
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s in %s' % (self.name, self.dc)
 
 
+@python_2_unicode_compatible
 class Storage(models.Model):
     '''
     Datacenter may have storage facilities
@@ -269,10 +281,11 @@ class Storage(models.Model):
         verbose_name = _(u'Storage')
         verbose_name_plural = _(u'Storages')
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s in %s' % (self.name, self.dc)
 
 
+@python_2_unicode_compatible
 class RackPosition(models.Model):
     '''
     Racks can be positioned in a RackRow
@@ -287,7 +300,7 @@ class RackPosition(models.Model):
         verbose_name = _(u'Rack Position in Rack Row')
         verbose_name_plural = _(u'Rack Positions in Rack Rows')
 
-    def __unicode__(self):
+    def __str__(self):
         return _(u'Rack: %(rack)s, Position: %(position)02d, RackRow: %(rackrow)s') % {
             'rack': self.rack,
             'position': self.position,
@@ -295,6 +308,7 @@ class RackPosition(models.Model):
         }
 
 
+@python_2_unicode_compatible
 class EquipmentModel(Model):
     '''
     Equipments have Models
@@ -310,7 +324,7 @@ class EquipmentModel(Model):
         verbose_name = _(u'Equipment Model')
         verbose_name_plural = _(u'Equipment Models')
 
-    def __unicode__(self):
+    def __str__(self):
         return u'%s %s' % (self.vendor, self.name)
 
     @property
@@ -318,6 +332,7 @@ class EquipmentModel(Model):
         return reversed(range(1, self.u + 1))
 
 
+@python_2_unicode_compatible
 class Equipment(models.Model):
     '''
     Equipment model
@@ -355,7 +370,7 @@ class Equipment(models.Model):
         verbose_name = _(u'Equipment')
         verbose_name_plural = _(u'Equipments')
 
-    def __unicode__(self):
+    def __str__(self):
         out = u''
         if self.purpose:
             out += u'%s, ' % self.purpose
@@ -375,6 +390,7 @@ class Equipment(models.Model):
             return None
 
 
+@python_2_unicode_compatible
 class ServerManagement(models.Model):
     '''
     Equipments that can be managed have a ServerManagement counterpanrt
@@ -403,7 +419,7 @@ class ServerManagement(models.Model):
         verbose_name = _(u'Server Management')
         verbose_name_plural = _(u'Servers Management')
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s for %s' % (self.get_method_display(), self.equipment)
 
     def __sm__(self, action, username, password, **kwargs):
@@ -540,9 +556,9 @@ class ServerManagement(models.Model):
 
         return self.__sm__('firmware_update', username, password, **kwargs)
 
+
 # Auxiliary models
-
-
+@python_2_unicode_compatible
 class Ticket(models.Model):
     '''
     A ticket associated with a model
@@ -561,7 +577,7 @@ class Ticket(models.Model):
         verbose_name = _(u'Ticket')
         verbose_name_plural = _(u'Tickets')
 
-    def __unicode__(self):
+    def __str__(self):
         return u'Ticket: %s' % (self.name)
 
     def closed(self):

--- a/servermon/keyvalue/models.py
+++ b/servermon/keyvalue/models.py
@@ -23,10 +23,12 @@ Each keyvalue has three items.
 '''
 
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
 
 
+@python_2_unicode_compatible
 class Key(models.Model):
     '''
     The key part of the key value pair
@@ -36,7 +38,7 @@ class Key(models.Model):
     verbose_name = models.CharField(max_length=100, blank=True, help_text='Human readable version of the name')
     description = models.CharField(max_length=150, blank=True, help_text='Description of what this key represents')
 
-    def __unicode__(self):
+    def __str__(self):
         if self.description != u'':
             return u'%s - %s' % (self.name, self.description)
         return u'%s' % (self.name)
@@ -50,6 +52,7 @@ class Key(models.Model):
         super(Key, self).save(*args, **kwargs)
 
 
+@python_2_unicode_compatible
 class KeyValue(models.Model):
     '''
     Attach a key and a value to any instance of any django model.
@@ -81,7 +84,7 @@ class KeyValue(models.Model):
     def owner(self):
         return self.owner_content_object
 
-    def __unicode__(self):
+    def __str__(self):
         res = u'%s = %s on %s' % (
             self.key.name,
             self.value,

--- a/servermon/keyvalue/tests.py
+++ b/servermon/keyvalue/tests.py
@@ -52,9 +52,9 @@ class KeyTestCase(unittest.TestCase):
         self.assertEqual(self.key1, Key.objects.get(name='Key1'))
         # Test name field on Key
         self.assertEqual(self.key1.name, 'Key1')
-        # Test __unicode__ method on Key without description
+        # Test __str__ method on Key without description
         self.assertEqual(str(self.key1), 'Key1')
-        # Test __unicode__ method on Key with description
+        # Test __str__ method on Key with description
         self.assertEqual(str(self.key2), 'Key2 - Key 2')
 
     def test_keyvalue(self):
@@ -63,7 +63,7 @@ class KeyTestCase(unittest.TestCase):
         self.assertEqual(self.keyvalue.description, '')
         self.assertEqual(self.keyvalue.value, 'Yo')
         self.assertEqual(self.keyvalue.owner, self.owner)
-        # Test __unicode__ method on KeyValue
+        # Test __str__ method on KeyValue
         self.assertEqual(str(self.keyvalue), 'Key1 = Yo on Owner')
 
 

--- a/servermon/puppet/models.py
+++ b/servermon/puppet/models.py
@@ -20,6 +20,7 @@ puppet module's functions documentation. This has been create by django
 inspecting the puppet database
 '''
 
+from django.utils.encoding import python_2_unicode_compatible
 from django.db import models
 from django.conf import settings
 
@@ -43,6 +44,7 @@ class SourceFile(models.Model):
         managed = MANAGED_PUPPET_MODELS
 
 
+@python_2_unicode_compatible
 class Fact(models.Model):
     '''
     Modeling the respective puppet concept.
@@ -57,7 +59,7 @@ class Fact(models.Model):
         ordering = ['name']
         managed = MANAGED_PUPPET_MODELS
 
-    def __unicode__(self):
+    def __str__(self):
         '''
         Get a string representation of the instance
         '''
@@ -65,6 +67,7 @@ class Fact(models.Model):
         return self.name.replace('_', ' ').rstrip()
 
 
+@python_2_unicode_compatible
 class Host(models.Model):
     '''
     Modeling the respective puppet concept.
@@ -86,7 +89,7 @@ class Host(models.Model):
         ordering = ['name', ]
         managed = MANAGED_PUPPET_MODELS
 
-    def __unicode__(self):
+    def __str__(self):
         '''
         Get a string representation of the instance
         '''
@@ -146,7 +149,7 @@ class FactValue(models.Model):
 
         return self.fact_name.name
 
-    def __unicode__(self):
+    def __str__(self):
         '''
         Get a string representation of the instance
         '''

--- a/servermon/updates/models.py
+++ b/servermon/updates/models.py
@@ -18,12 +18,13 @@
 updates module's functions documentation. Main models are Package and Update
 '''
 
-
+from django.utils.encoding import python_2_unicode_compatible
 from django.db import models
 from puppet.models import Host
 import re
 
 
+@python_2_unicode_compatible
 class Package(models.Model):
     '''
     A Debian package
@@ -36,13 +37,14 @@ class Package(models.Model):
     class Meta:
         ordering = ('name', )
 
-    def __unicode__(self):
+    def __str__(self):
         if self.name == self.sourcename:
             return self.name
         else:
             return "%s (%s)" % (self.name, self.sourcename)
 
 
+@python_2_unicode_compatible
 class Update(models.Model):
     '''
     Modeling a potential update to a package
@@ -56,7 +58,7 @@ class Update(models.Model):
     origin = models.CharField(max_length=200, null=True)
     is_security = models.BooleanField(default=False)
 
-    def __unicode__(self):
+    def __str__(self):
         '''
         Returns the objects unicode representation
         '''


### PR DESCRIPTION
Specifying the __unicode__() function in python 3 is effectively a noop
as it no longer has special treatment as it does in python 2. Instead
__str__ is meant to be used. However that function has a different
meaning in python 2 and Django is kind enough to provide a decorator
that handles that trasparently for us. Use that decorator wherever we
used to specify the __unicode__() function and convert all __unicode__
instances to __str__