### PR TITLE
Make sure we make encapsulate strings in an iterable

### DIFF
--- a/servermon/hwdoc/functions.py
+++ b/servermon/hwdoc/functions.py
@@ -55,8 +55,12 @@ def search(q):
     # to create one than fail
     try:
         q.__iter__()
+        # But if we have a string, do it anyway to avoid python 3's __iter__()
+        # capable strings
+        if isinstance(q, str):
+            q = (q, )
     except AttributeError:
-        q = (q,)
+        q = (q, )
 
     ids = []
 


### PR DESCRIPTION
We used to rely on a not very future proof behavior of strings, that is
that they did not have the __iter__() function whereas still being
iterables. This is not python 3 compatible however given strings do have
an __iter__() function in python 3. Detect if it is a string we are
talking about and force the tuple