### PR TITLE
Don't use BaseException.message

### DIFF
--- a/servermon/projectwide/management/commands/dev_fixtures.py
+++ b/servermon/projectwide/management/commands/dev_fixtures.py
@@ -269,7 +269,7 @@ class Command(BaseCommand):
                 sys.stdout = stdout
                 f.close()
         except Exception as e:
-            print('Error: %s, %s' % (e.__class__, e.message))
+            print('Error: %s, %s' % (e.__class__, e))
         # Unconditionally rollback always. We just pummeled the database for
         # nothing
         transaction.rollback()


### PR DESCRIPTION
It has been deprecated since a long time and __repr__ and __str__ are
already doing the right thing anyway