### PR TITLE
UnicodeEncodeError's base class in exception handling

### DIFF
--- a/servermon/hwdoc/functions.py
+++ b/servermon/hwdoc/functions.py
@@ -68,7 +68,7 @@ def search(q):
         for key in q:
             try:
                 dns = gethostbyaddr(key)[0]
-            except (herror, gaierror, IndexError, error, UnicodeEncodeError):
+            except (herror, gaierror, IndexError, error, UnicodeError):
                 dns = ''
             mac = canonicalize_mac(key)
             # A heuristic to allow user to filter queries down to the unit level


### PR DESCRIPTION
Use instead of UnicodeEncodeError, the UnicodeError base class. We do
this because in python 3 the base class is used instead of the child
class