### PR TITLE
 Use deprecated-2017Q4 as a travis image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ python:
   - "2.7"
 install: pip install tox
 script: tox
-sudo: false
+sudo: required
+dist: trusty
+group: deprecated-2017Q4
 env:
   - DB=sqlite
   - DB=mysql


### PR DESCRIPTION
In order to avoid using postgres 10.1, we are definitely not ready for anything like it yet