### PR TITLE
garbage collection host support

### DIFF
--- a/servermon/servermon/settings.py.dist
+++ b/servermon/servermon/settings.py.dist
@@ -175,6 +175,7 @@ SKIP_SOUTH_TESTS = True
 DATE_FORMAT = "d/m/Y H:i"
 DATETIME_FORMAT = "d/m/Y H:i"
 HOST_TIMEOUT = 1800
+HOST_MAX_INACTIVE_DAYS = 10 # After that many days puppet hosts will be deleted. This is a GC solution in case you don't have one already
 MANAGED_PUPPET_MODELS = False
 
 # Ticketing


### PR DESCRIPTION
In many environments, active record is no longer used and people have
migrated to PuppetDB. Puppet 4 does not even support ActiveRecord
anymore. For these cases and until we support PuppetDB, do a garbage
collection of hosts. Piggyback in the make_updates command for that,
which is not architecturally the best option but is good enough for now