### PR TITLE
Drop --no-use-wheel from pip incantations

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ setenv = VIRTUAL_ENV={envdir}
          LC_ALL=C
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 skip_install = True
-install_command = pip install --no-use-wheel {opts} {packages}
+install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
        django14: Django>=1.4,<1.5
        django15: Django>=1.5,<1.6


### PR DESCRIPTION
It was deprecated for a long time now and it's no longer supported.
Remove it